### PR TITLE
Add WhoIs panel, stalk prompt, and UI tweaks

### DIFF
--- a/app/NX/DesignSystem/components/Icon.tsx
+++ b/app/NX/DesignSystem/components/Icon.tsx
@@ -185,11 +185,16 @@ import SeniorityIcon from '@mui/icons-material/Elderly';
 import FlagonIcon from '@mui/icons-material/Flag';
 import FlagoffIcon from '@mui/icons-material/FlagOutlined';
 import ProspectsIcon from '@mui/icons-material/DataSaverOff';
+import StalkIcon from '@mui/icons-material/Camera';
 
 export default function Icon({ icon, color }: I_Icon) {
   if (!color) color = 'inherit';
   let iconFragment = <React.Fragment />;
   switch (icon) {
+
+    case 'stalk':
+      iconFragment = <StalkIcon color={color} />;
+      break;
     case 'flagon':
       iconFragment = <FlagonIcon color={color} />;
       break;

--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -103,6 +103,12 @@ export default function Prospects({
                     <Container maxWidth="lg" sx={{ my: 3 }}>
 
                         <Grid container spacing={2}>
+
+                            <Grid size={{ xs: 12 }}>
+                                <Box sx={{ mx: 1, mt: 1 }}>
+                                    <Search />
+                                </Box>
+                            </Grid>
                             
                             <Grid size={{ xs: 6 }}>
                                 <ChipSelect
@@ -124,11 +130,7 @@ export default function Prospects({
                                 />
                             </Grid>
 
-                            <Grid size={{ xs: 12 }}>
-                                <Box sx={{mx:1, mt:1}}>
-                                    <Search />
-                                </Box>
-                            </Grid>
+                            
 
                         </Grid>
                     </Container>
@@ -143,6 +145,7 @@ export default function Prospects({
                         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
                             <Pagination
                                 sx={{mb:4}}
+                                size="small"
                                 count={pagination.pages}
                                 page={pagination.page}
                                 onChange={handlePageChange}

--- a/app/NX/Prospects/README.md
+++ b/app/NX/Prospects/README.md
@@ -1,4 +1,11 @@
-## MVP
+## Prospects™
+
+As a user I want to identify a single prospect to 
+focus on. The goal is to be as quick and accurate as possible 
+with as few clicks/taps and keyboard inputs as possible
+
+
+#### MVP vs PoC
 
 A demo is when a developer shows you something on his computer. It could be smoke & mirrors, you can't trust it. This is the next step. Proof of Concept. Or Minimum Viable Product. Depends how polished it is.
 
@@ -6,12 +13,7 @@ The concept we are trying to prove is this... Yes, yes NX - very good, but how d
 
 And if so, does it ACTUALLY increase the number of responses/sales/etc? 
 
+#### Extra points
 
-## The app.
-
-As a user I want to identify a single prospect to 
-focus on. The goal is to be as quick and accurate as possible 
-with as few clicks/taps and keyboard inputs as possible
-
-- List of prospects matching the search. Starts off empty
+- List of prospects matching the search. Starts off full
 - List of favourites

--- a/app/NX/Prospects/actions/flagProspect.tsx
+++ b/app/NX/Prospects/actions/flagProspect.tsx
@@ -22,12 +22,14 @@ export const flagProspect = (
     async (dispatch: T_UbereduxDispatch) => {
         try {
             const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects/${id}`;
+            dispatch(setProspects('flagging', true));
             await patchJson(endpoint, { flag });
             dispatch(searchProspects());
             dispatch(setFeedback({ 
                 severity: 'success',
                 title: successMessage,
             }));
+            dispatch(setProspects('flagging', false));
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             dispatch(setProspects('error', msg));

--- a/app/NX/Prospects/components/Prompt.tsx
+++ b/app/NX/Prospects/components/Prompt.tsx
@@ -53,16 +53,25 @@ export default function Prompt({ result }: I_Prompt) {
                         }
                     }}
                 /> */}
+            <Button
+                fullWidth
+                variant="outlined"
+                color="primary"
+                startIcon={<Icon icon="linkedin" />}
+                onClick={() => {
+                    dispatch(sendPrompt(prompt));
+                }}>
+                Who is?
+            </Button>
                 <Button 
-                    sx={{mx:1, mb:2}}
                     fullWidth
-                    variant="contained" 
+                    variant="outlined" 
                     color="primary" 
-                    startIcon={<Icon icon="ai" />}
+                    startIcon={<Icon icon="email" />}
                     onClick={() => {
                         dispatch(sendPrompt(prompt));
                     }}>
-                    Do the clever thing
+                    Write email
                 </Button>
         </>
     );

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -6,6 +6,7 @@ import {
     Tooltip,
     useTheme,
     useMediaQuery,
+    CircularProgress,
     ButtonBase,
     Typography,
     Box,
@@ -32,6 +33,8 @@ import {
     hideProspect,
     flagProspect,
     Prompt,
+    WhoIs,
+    useProspects,
 } from '../../Prospects'
 
 
@@ -65,6 +68,9 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const [copied, setCopied] = React.useState(false);
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const hostname = emailToHostname(result.email as string);
+    const prospects = useProspects();
+    const flagging = prospects?.flagging;
+    // console.log("flagging", flagging);
 
     const handleResultClick = () =>  setOpen(true);
     const handleClose = () => setOpen(false);
@@ -130,12 +136,18 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                             >
                                 <Icon icon="hide" />
                             </IconButton>
-                            <IconButton
-                                onClick={handleFlag}
-                                color="primary"
-                            >
-                                <Icon icon={!!result.flag ? "flagon" : "flagoff"} />
-                            </IconButton>
+                            {flagging ? (
+                                <IconButton>   
+                                    <CircularProgress size={24} color="primary" />
+                                </IconButton>   
+                            ) : (
+                                <IconButton
+                                    onClick={handleFlag}
+                                    color="primary"
+                                >
+                                    <Icon icon={!!result.flag ? "flagon" : "flagoff"} />
+                                </IconButton>
+                            )}
                             
                             <IconButton
                                 onClick={handleClose}
@@ -206,6 +218,8 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                             </List>
                         </Grid>
                     </Grid>
+
+                    <WhoIs result={result} />
                 </DialogContent>
                 <DialogActions>
                     <Prompt result={result} />

--- a/app/NX/Prospects/components/WhoIs.tsx
+++ b/app/NX/Prospects/components/WhoIs.tsx
@@ -1,0 +1,78 @@
+"use client";
+import * as React from "react";
+import type { T_ApolloDoc } from '../types';
+import {
+    useTheme,
+    useMediaQuery,
+    Button,
+    Typography,
+} from "@mui/material";
+import { useDispatch } from '../../Uberedux';
+import { 
+    // sendPrompt, --- IGNORE ---
+} from '../../Prospects';
+import {Icon} from '../../DesignSystem';
+import { promptMagentoPlugin, stalkPrompt } from '../../Prospects'
+
+export interface I_WhoIs {
+    result?: T_ApolloDoc;
+}
+
+export default function WhoIs({ result }: I_WhoIs) {
+
+    const dispatch = useDispatch();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+    const {
+        first_name = '',
+        last_name = '',
+        person_linkedin_url = '',
+        title = '',
+        company_name = '',
+        seniority = '',
+        sub_departments = '',
+        country = '',
+        primary_intent_topic = '',
+        primary_intent_score = '',
+        secondary_intent_topic = '',
+        secondary_intent_score = '',
+    } = result || {};
+
+    const summary = `Click to stalk ${first_name} ${last_name}${title ? `, ${title}` : ''}${company_name ? ` at ${company_name}` : ''} by looking up their LinkedIn profile`;
+
+    const prompt = stalkPrompt({
+        first_name,
+        last_name,
+        person_linkedin_url,
+        title,
+        company_name,
+        seniority,
+        sub_departments,
+        country,
+        primary_intent_topic,
+        primary_intent_score,
+        secondary_intent_topic,
+        secondary_intent_score,
+    });
+
+    return (
+            <>
+            {/* <pre style={{fontSize:9}}>{JSON.stringify(prompt, null, 2)}</pre> */}
+             <Typography variant="body2" sx={{my:2}}>
+                {summary}
+            </Typography>   
+            <Button
+                
+                variant="contained"
+                color="primary"
+                startIcon={<Icon icon="stalk" />}
+                onClick={() => {
+                    // dispatch(sendWhoIs(prompt));
+                }}>
+                Stalk {first_name}
+            </Button>
+        </>
+    );
+}
+

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -4,6 +4,7 @@ import Selecta from './components/Selecta';
 import Basket from './components/Basket';
 import Result from './components/Result';
 import Prompt from './components/Prompt';
+import WhoIs from './components/WhoIs';
 import ChipSelect from './components/ChipSelect';
 import { initProspects } from './actions/initProspects';
 import { addToBasket } from './actions/addToBasket';
@@ -14,7 +15,7 @@ import { setProspects } from './actions/setProspects';
 import { useInitialData } from './hooks/useInitialData';
 import { useProspects } from './hooks/useProspects';
 import { useTable } from './hooks/useTable';
-import { promptMagentoPlugin } from './lib/prompts';
+import { promptMagentoPlugin, stalkPrompt } from './lib/prompts';
 import { normaliseForChipSelect } from './lib/normalise';
 import { sendPrompt } from './actions/sendPrompt';
 import { flagProspect } from './actions/flagProspect';
@@ -34,6 +35,7 @@ export {
     ChipSelect,
     Basket,
     Prompt,
+    WhoIs,
     updateQuery,
     resetQuery,
     addToBasket,
@@ -42,4 +44,6 @@ export {
     promptMagentoPlugin,
     flagProspect,
     hideProspect,
+
+    stalkPrompt,
 };

--- a/app/NX/Prospects/lib/prompts.tsx
+++ b/app/NX/Prospects/lib/prompts.tsx
@@ -1,3 +1,79 @@
+export const stalkPrompt = ({
+    first_name,
+    last_name,
+    person_linkedin_url,
+    title,
+    company_name,
+    seniority,
+    sub_departments,
+    country,
+    primary_intent_topic,
+    primary_intent_score,
+    secondary_intent_topic,
+    secondary_intent_score,
+}: {
+    first_name: string;
+    last_name: string;
+    person_linkedin_url: string;
+    title?: string;
+    company_name?: string;
+    seniority?: string;
+    sub_departments?: string;
+    country?: string;
+    primary_intent_topic?: string;
+    primary_intent_score?: string;
+    secondary_intent_topic?: string;
+    secondary_intent_score?: string;
+}) => {
+    return `
+You are a B2B sales intelligence analyst.
+
+Your task is to analyse a prospect based on the provided data and infer useful commercial insights.
+
+=== PERSON ===
+Name: ${first_name} ${last_name}
+LinkedIn: ${person_linkedin_url}
+Title: ${title ?? "Unknown"}
+Company: ${company_name ?? "Unknown"}
+Seniority: ${seniority ?? "Unknown"}
+Department: ${sub_departments ?? "Unknown"}
+Country: ${country ?? "Unknown"}
+
+=== INTENT SIGNALS ===
+Primary topic: ${primary_intent_topic ?? "None"} (${primary_intent_score ?? "0"})
+Secondary topic: ${secondary_intent_topic ?? "None"} (${secondary_intent_score ?? "0"})
+
+=== INSTRUCTIONS ===
+- Infer responsibilities based on title and seniority
+- Estimate decision-making power (low / medium / high)
+- Identify likely business priorities
+- Identify pain points related to the intent topics
+- Assess how relevant they are as a prospect
+- Be pragmatic and commercially focused
+
+- If data is missing, make reasonable assumptions
+- Do NOT mention missing data
+- Do NOT be vague
+
+=== OUTPUT ===
+Return ONLY valid JSON in this format:
+
+{
+  "summary": string, // 2-3 sentence overview of the person
+  "role_inference": string, // what they actually do day-to-day
+  "seniority_level": "low" | "medium" | "high",
+  "decision_power": "low" | "medium" | "high",
+  "key_priorities": string[],
+  "likely_pain_points": string[],
+  "intent_alignment": string, // how well intent signals match their role
+  "prospect_score": number, // 0-100
+  "prospect_grade": "A" | "B" | "C" | "D",
+  "recommendation": string // should we target them and why
+}
+`;
+};
+
+
 export const promptMagentoPlugin = ({
     first_name,
     last_name,

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -463,6 +463,7 @@ export type I_Icon = {
     | 'menu'
     | 'success'
     | 'flagoff'
+    | 'stalk'
     | 'flagon'
     | 'categories'
     | 'category'


### PR DESCRIPTION
Introduce a WhoIs feature to surface a “stalk” action for prospects: add a new WhoIs component, a stalkPrompt generator, and wire it into Prospects exports. Add a new `stalk` icon (Camera) and update I_Icon types. Improve UX: move Search up in the Prospects layout, set Pagination size to small, and change Prompt buttons (add “Who is?” and rename the other to “Write email”). Add optimistic UI for flagging: set a `flagging` state during flag/unflag requests in flagProspect and show a CircularProgress spinner in Result while flagging. Update README copy for Prospects. These changes add the stalking prompt and polish the UI/feedback around flagging and search placement.