### PR TITLE
This pull request refactors the shortcodes system by renaming and updating the `ChatResponse` component to `CleverTextShortcode`, 

### DIFF
--- a/app/NX/Shortcodes/components/CleverTextShortcode.tsx
+++ b/app/NX/Shortcodes/components/CleverTextShortcode.tsx
@@ -2,24 +2,23 @@
 import React from 'react';
 import {
   Box,
-  Typography,
 } from '@mui/material';
 import { CleverText } from '../../DesignSystem';
 
-
-export default function ChatResponse({
-  text = '',
+export default function CleverTextShortcode({
+  text = null
 }: {
-  text?: string;
+  text?: string | null;
 }) {
-
+  if (!text) return null;
+  
   return (
     <Box>
       <CleverText options={{ 
         id: 'cleverText', 
         markdown: text,
         onFinish: () => {
-          // console.log('Finished typing');
+          console.log('CleverTextShortcode');
         },
       }} />
     </Box>

--- a/app/NX/Shortcodes/components/PageLink.tsx
+++ b/app/NX/Shortcodes/components/PageLink.tsx
@@ -11,15 +11,15 @@ import { Icon, navigateTo } from '../../DesignSystem';
 import { useDispatch } from '../../Uberedux';
 
 export default function PageLink({
-  url = '',
-  icon = 'link',
-  title = 'No title',
-  description = 'No description'
+  url = null,
+  icon = null,
+  title = null,
+  description = null
 }: {
   url?: string;
-  icon?: string;
-  title?: string;
-  description?: string;
+  icon?: string | null;
+  title?: string | null;
+  description?: string | null;
 }) {
 
   const dispatch = useDispatch();

--- a/app/NX/Shortcodes/components/PageLink.tsx
+++ b/app/NX/Shortcodes/components/PageLink.tsx
@@ -12,11 +12,11 @@ import { useDispatch } from '../../Uberedux';
 
 export default function PageLink({
   url = null,
-  icon = null,
+  icon = 'link',
   title = null,
   description = null
 }: {
-  url?: string;
+  url?: string | null;
   icon?: string | null;
   title?: string | null;
   description?: string | null;

--- a/app/NX/Shortcodes/components/RenderMarkdown.tsx
+++ b/app/NX/Shortcodes/components/RenderMarkdown.tsx
@@ -11,7 +11,7 @@ import {
 import {
   BuyNow,
   FeedbackBtn,
-  ChatResponse,
+  CleverTextShortcode,
   GithubLink,
   ContentCard,
   PageLink,
@@ -67,11 +67,11 @@ export default function RenderMarkdown({
     const feedbackBtn = parseShortcode(/\[FeedbackBtn\s+(.*?)\]/, FeedbackBtn);
     if (feedbackBtn) return feedbackBtn;
 
-    // ChatResponse
-    const chatResponse = parseShortcode(/\[ChatResponse\s+(.*?)\]/, ChatResponse);
-    if (chatResponse) return chatResponse;
+    // CleverText
+    const cleverText = parseShortcode(/\[CleverText\s+(.*?)\]/, CleverTextShortcode);
+    if (cleverText) return cleverText;
 
-    // ChatResponse
+    // GithubLink
     const githubLink = parseShortcode(/\[GithubLink\s+(.*?)\]/, GithubLink);
     if (githubLink) return githubLink;
 

--- a/app/NX/Shortcodes/index.tsx
+++ b/app/NX/Shortcodes/index.tsx
@@ -2,7 +2,7 @@
 import BuyNow from "./components/BuyNow";
 import GithubLink from "./components/GithubLink";
 import FeedbackBtn from "./components/FeedbackBtn";
-import ChatResponse from "./components/ChatResponse";
+import CleverTextShortcode from "./components/CleverTextShortcode";
 import ContentCard from "./components/ContentCard";
 import RenderMarkdown from "./components/RenderMarkdown";
 import PageLink from "./components/PageLink";
@@ -11,7 +11,7 @@ export {
     RenderMarkdown,
     BuyNow,
     FeedbackBtn,
-    ChatResponse,
+    CleverTextShortcode,
     GithubLink,
     ContentCard,
     PageLink,

--- a/public/free/markdown/features/index.md
+++ b/public/free/markdown/features/index.md
@@ -1,7 +1,7 @@
 ---
 order: 191
 title: Features
-description: Powerful Features at a Glance
+description: Built on Next.js & Python
 slug: /features
 icon: features
 tags: features
@@ -9,9 +9,11 @@ tags: features
 
 NX is a modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.
 
+[PageLink url="/features/pwa" title="Progressive Web Apps™" ]  
 
 - PWA Support: Offline-ready with service workers
 - Multi-Tenant Architecture: Easily support multiple brands/clients
 - RESTful API: Built-in API endpoints ([API Docs](https://goldlabel.pro/api))
 - Design System: Reusable components and hooks
 - Rich Media Support: Markdown, images, SVG, PDF, and more
+

--- a/public/free/markdown/features/pwa.md
+++ b/public/free/markdown/features/pwa.md
@@ -1,0 +1,13 @@
+---
+order: 192
+title: PWA
+description: Progressive Web Apps
+slug: /features/pwa
+icon: features
+tags: features, pwa
+---
+
+[PageLink url="/prospects" title="Prospects™" ]  
+
+[CleverText text="A Progressive Web App (PWA) is a web application that uses modern browser features to deliver a fast, reliable, app-like experience across devices, including offline access and installability."]
+

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -10,6 +10,6 @@ image: /free/png/apps.png
 
 [PageLink icon="prospects" title="Prospects™" description="Be more direct" url="/prospects"]  
 
-[ChatResponse text="In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins."]
+[CleverText text="In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins."]
 
 [GithubLink  label="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  

--- a/public/free/markdown/techstack/index.md
+++ b/public/free/markdown/techstack/index.md
@@ -7,8 +7,7 @@ icon: techstack
 tags: about, techstack
 ---
 
-[ContentCard slug="/techstack/nextjs"]  
-[ContentCard slug="/techstack/python"]  
+[PageLink icon="js" title="NextJS" url="/techstack/nextjs"]  
 
 - **Next.js 16**: SSR, SSG, API routes, and advanced routing
 - **TypeScript**: Strict typing and modern JavaScript features

--- a/public/free/markdown/techstack/nextjs.md
+++ b/public/free/markdown/techstack/nextjs.md
@@ -7,4 +7,4 @@ tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
 icon: techstack
 ---
 
-- **Next.js 16**: SSR, SSG, API routes, and advanced routing
+[Clevertext text="Next.js 16 SSR, SSG, API routes, and advanced routing"]

--- a/public/free/markdown/techstack/nextjs.md
+++ b/public/free/markdown/techstack/nextjs.md
@@ -7,4 +7,4 @@ tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
 icon: techstack
 ---
 
-[Clevertext text="Next.js 16 SSR, SSG, API routes, and advanced routing"]
+[CleverText text="Next.js 16 SSR, SSG, API routes, and advanced routing"]


### PR DESCRIPTION
updates its usage throughout the codebase, and improves how shortcodes are parsed and rendered. Additionally, it modifies the `PageLink` and related shortcodes for better null handling and updates markdown content to use the new components.

**Shortcodes component refactor:**

- Renamed `ChatResponse.tsx` to `CleverTextShortcode.tsx`, updated the component to use `null` as the default for `text`, and changed the console log message.
- Updated all imports and usages of `ChatResponse` to `CleverTextShortcode` in `RenderMarkdown`, the shortcodes index, and the export list. [[1]](diffhunk://#diff-37b909a8b85dafc0c86d175c2fe69d72176a95c79ad8a7341fc89bfbca92c1b6L14-R14) [[2]](diffhunk://#diff-37b909a8b85dafc0c86d175c2fe69d72176a95c79ad8a7341fc89bfbca92c1b6L70-R74) [[3]](diffhunk://#diff-1c546428021846608aa3865dcf2f174fc0e07689e334f95ec15590324a80b3aaL5-R5) [[4]](diffhunk://#diff-1c546428021846608aa3865dcf2f174fc0e07689e334f95ec15590324a80b3aaL14-R14)

**Shortcodes parsing improvements:**

- Changed the `RenderMarkdown` component to parse and render the `[CleverText ...]` shortcode instead of `[ChatResponse ...]`.

**Component prop handling:**

- Updated `PageLink` to use `null` as the default value for all props, improving type safety and consistency.

**Markdown content updates:**

- Updated `techstack/index.md` to use the `[PageLink ...]` shortcode instead of `[ContentCard ...]`.
- Updated `techstack/nextjs.md` to use the `[CleverText ...]` shortcode for describing Next.js features.