### PR TITLE
Add GitHub button, external-link logic & docs

### DIFF
--- a/app/NX/DesignSystem/components/Nav.tsx
+++ b/app/NX/DesignSystem/components/Nav.tsx
@@ -66,6 +66,11 @@ const Nav: React.FC<I_Nav> = ({
             setDrawerOpen(false);
     }
 
+    function handleGithubClick() {
+        // dispatch(navigateTo(router, '/'));
+        setDrawerOpen(false);
+    }
+
     function renderNavItems(
         items: I_NavNode[],
         parentKey = '',
@@ -139,8 +144,6 @@ const Nav: React.FC<I_Nav> = ({
                         <TreeNav navItems={navItems}/>
                         <Box sx={{ mt: 'auto', display: 'flex' }}>
                             
-                            
-
                             <Box sx={{ mt: 1, ml: 2 }}>
                                 <Virus frontmatter={frontmatter} />
                             </Box>
@@ -153,6 +156,15 @@ const Nav: React.FC<I_Nav> = ({
                                 </Box>
                             </>}
                             
+                            
+                            <Box sx={{ ml: 1 }}>
+                                <IconButton
+                                    color="primary"
+                                    onClick={handleGithubClick}>
+                                    <Icon icon={'github'} />
+                                </IconButton>
+                            </Box>
+                            
                             <Box sx={{ ml: 1 }}>
                                 <IconButton
                                     color="primary"
@@ -160,6 +172,7 @@ const Nav: React.FC<I_Nav> = ({
                                     <Icon icon={'home'} />
                                 </IconButton>
                             </Box>
+
                         </Box>
                     </Box>
                 </Drawer>

--- a/app/NX/Shortcodes/components/PageLink.tsx
+++ b/app/NX/Shortcodes/components/PageLink.tsx
@@ -27,7 +27,8 @@ export default function PageLink({
 
   const handleClick = () => {
     if (url) {
-      dispatch(navigateTo(router, url, '_self'));
+      const isExternal = url.startsWith('http');
+      dispatch(navigateTo(router, url, isExternal ? '_blank' : '_self'));
     }
   };
 

--- a/public/free/markdown/apps/index.md
+++ b/public/free/markdown/apps/index.md
@@ -1,0 +1,12 @@
+---
+order: 100
+title: Apps
+description: What is a tenant?
+slug: /apps
+icon: company
+tags: tenants, apps,
+---
+
+[PageLink icon="right" title="Prospects™" url="/prospects"]  
+
+> [CleverText text="Imagine you rent a shop in a posh shopping mall..."]  

--- a/public/free/markdown/apps/prospects.md
+++ b/public/free/markdown/apps/prospects.md
@@ -2,7 +2,7 @@
 order: 701
 title: Prospects™
 description: Be more direct
-slug: /prospects
+slug: /apps/prospects
 icon: prospects
 image: /free/png/apps.png
 tags: PWA, fast search, tsvector, python

--- a/public/free/markdown/github.md
+++ b/public/free/markdown/github.md
@@ -1,5 +1,5 @@
 ---
-order: 201
+order: 801
 title: GitHub
 description: Always Free, always Open Source
 slug: /github

--- a/public/free/markdown/techstack/index.md
+++ b/public/free/markdown/techstack/index.md
@@ -10,12 +10,16 @@ tags: about, techstack
 [PageLink icon="js" title="NextJS" url="/techstack/nextjs"]  
 
 - **Next.js 16**: SSR, SSG, API routes, and advanced routing
+- **Material UI (MUI)**: Beautiful, accessible UI components
+- **Redux Toolkit**: State management
 - **TypeScript**: Strict typing and modern JavaScript features
+- **Firebase**: Authentication and backend integration
+- **Vercel**: Deployment
+
+[PageLink icon="api" title="Python" url="/techstack/python"]  
+
 - **Python 3.x**
 - **FastAPI** (web framework)
 - **Render** (deployment platform)
 - **Postgres** (database)
 - **tsvector** (for lightning-fast full-text search)
-- **Material UI (MUI)**: Beautiful, accessible UI components
-- **Redux Toolkit**: State management
-- **Firebase**: Authentication and backend integration

--- a/public/free/markdown/techstack/nextjs.md
+++ b/public/free/markdown/techstack/nextjs.md
@@ -2,9 +2,12 @@
 order: 485
 slug: /techstack/nextjs
 title: NextJS
-description: SSR, SSG, API routes, and advanced routing
-tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
+description: Node and React
+tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres, SSR, SSG, API routes, advanced routing,
 icon: techstack
 ---
+[PageLink icon="github" title="Template" description="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  
 
-[CleverText text="Next.js 16 SSR, SSG, API routes, and advanced routing"]
+Next.js is a leading modern web framework that seamlessly combines the power of React for building user interfaces with robust server-side features
+
+> [CleverText text="The world’s most popular environment for developing fast, scalable, and production-ready web applications"]

--- a/public/free/markdown/techstack/python.md
+++ b/public/free/markdown/techstack/python.md
@@ -2,19 +2,11 @@
 order: 480
 slug: /techstack/python
 title: Python
-description: Python with FastAPI using Postgres & tsvector
+description: FastAPI, Postgres & tsvector
 tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
-image: /free/png/python.png
 icon: techstack
 ---
-
-[ChatResponse text="Superfast search with tsvector"]
-
-## Tech Stack Overview
-
-Our application leverages a modern Python backend built with **FastAPI**, providing high performance and easy-to-use APIs. The app is deployed on [Render](https://render.com/), ensuring reliable and scalable hosting.
-
-For data storage, we use **Postgres** as our primary database. A crucial and distinctive feature of our stack is the use of the **tsvector** data type in Postgres. By utilizing tsvector for full-text search, our application achieves superfast and efficient search capabilities, even with large datasets. This enables users to experience near-instantaneous search results, making our platform highly responsive and scalable.
+[PageLink icon="github" title="Python" description="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
 
 - Python 3.x
 - FastAPI (web framework)
@@ -22,11 +14,12 @@ For data storage, we use **Postgres** as our primary database. A crucial and dis
 - Postgres (database)
 - tsvector (for lightning-fast full-text search)
 
-This combination ensures a robust, production-ready, and open-source solution optimized for speed and reliability.
+A modern Python backend built with **FastAPI**, providing high performance and easy-to-use APIs. The app is deployed on [Render](https://render.com/), ensuring reliable and scalable hosting. For data storage, we use **Postgres** as our primary database. 
 
-Python with FastAPI using Postgres & tsvector. Open Source, production ready Python FastAPI/Postgres app
+> [CleverText text="Superfast search with tsvector"]  
 
-- [GitHub](https://github.com/goldlabelapps/python-nx-ai)
-- [NX](https://goldlabel.pro?s=python-nx-ai)
-- [NX-AI](https://nx-ai.onrender.com/)
+A crucial and distinctive feature of our stack is the use of the **tsvector** data type in Postgres. By utilizing tsvector for full-text search, our application achieves superfast and efficient search capabilities, even with large datasets. 
+This enables users to experience near-instantaneous search results, 
+making our platform highly responsive and scalable.
 
+This combination ensures a robust, production-ready, and open-source solution optimized for speed and reliability


### PR DESCRIPTION
UI: Add a GitHub IconButton to the Nav drawer with a handler that closes the drawer. Fix PageLink to open external URLs in a new tab (detects urls starting with "http").

Docs: Add new apps index page and move prospects.md into public/free/markdown/apps (update slug). Update several techstack pages: refine techstack/index features and links, update NextJS page metadata and add a GitHub template link, and reorganize Python doc content (add GitHub link, emphasize FastAPI/Postgres/tsvector, and clean up copy). Also adjust order on github.md.