### PR TITLE
Paywall: add onClose, account guards; update links

### DIFF
--- a/app/NX/Paywall/components/MiniAccount.tsx
+++ b/app/NX/Paywall/components/MiniAccount.tsx
@@ -22,14 +22,14 @@ import {
 import { useDispatch } from '../../Uberedux';
 import { Icon, EditableStr } from '../../DesignSystem';
 
-export default function MiniAccount() {
+export default function MiniAccount({ onCloseDrawer }: { onCloseDrawer?: () => void } = {}) {
 
     const dispatch = useDispatch();
     const paywall = usePaywall();
     const { account } = paywall || {};
     const {
-        avatar,
-        level,
+        // avatar,
+        // level,
         name,
         email,
     } = account || {}; 
@@ -44,6 +44,7 @@ export default function MiniAccount() {
         dispatch(setPaywall('user', null));
         dispatch(setPaywall('account', null));
         setOpen(false);
+        if (onCloseDrawer) onCloseDrawer();
     }
     
     const onNameSave = (newName: string) => {
@@ -65,11 +66,13 @@ export default function MiniAccount() {
                     onSave={onNameSave}
                 />}
                 subheader={email}
-                action={<IconButton 
-                    color="primary" 
-                    onClick={handleOpen}>
-                    <Icon icon="signout" />
-                </IconButton>}
+                                action={name || email ? (
+                                    <IconButton 
+                                        color="primary" 
+                                        onClick={handleOpen}>
+                                        <Icon icon="signout" />
+                                    </IconButton>
+                                ) : null}
             />
             
         </Box>

--- a/app/NX/Paywall/components/UserSpot.tsx
+++ b/app/NX/Paywall/components/UserSpot.tsx
@@ -47,7 +47,9 @@ export default function UserSpot({ onClick }: I_UserSpot) {
         }
     }, []);
 
+
     if (!show) return null;
+    if (!account) return null;
 
     return (
         <IconButton onClick={onClick} color="primary" sx={{ mt: 1 }}>

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -5,9 +5,10 @@ title: NX
 description: by Goldlabel
 tags: NX, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 icon: goldlabel
-image: /free/png/apps.png
 ---
-
-[PageLink icon="techstack" title="Techstack" url="/techstack"]  
-[PageLink icon="prospects" title="Prospects™" url="/apps/prospects"]  
+[PageLink icon="prospects" title="Prospects™" description="Example App" url="/apps/prospects"]  
+[PageLink icon="features" title="Techstack" url="/techstack"]  
+[PageLink icon="features" title="Python" url="/techstack/python"]  
+[PageLink icon="features" title="NextJS" url="/techstack/nextjs"]  
 [PageLink icon="features" title="Features" url="/features"]  
+ 


### PR DESCRIPTION
MiniAccount: accept an optional onCloseDrawer callback and invoke it on sign-out; comment out unused avatar/level destructuring; only show the sign-out IconButton when name or email exist. UserSpot: avoid rendering when account is missing (early return). public/free/markdown/index.md: remove the image/section separation and update/reorder PageLink entries (add Python and NextJS links and adjust descriptions). These changes prevent rendering when account data is absent and wire up drawer close behavior on sign-out, plus refresh the free markdown landing links.