### PR TITLE
Add PWA content and index links; adjust icon spacing

### DIFF
--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -158,7 +158,7 @@ export default async function Page(props: any) {
                             <Box component="main" sx={{ gridColumn: { lg: '1' }, width: '100%', minWidth: 0, pr: { xs: 2, lg: 3 }, pl: { xs: 2, lg: 0 }, flexGrow: 1 }}>
                                 <Typography sx={{ display: 'flex', mt: 1 }} color='secondary' variant="h6" component="h2">
                                     <Box sx={{ display: 'flex', width: '100%' }}>
-                                        {data.icon && <Box sx={{ mr: 2 }}><Icon icon={data.icon} color="primary" /></Box>}
+                                        {data.icon && <Box sx={{ mx: 2 }}><Icon icon={data.icon} color="primary" /></Box>}
                                         <Box sx={{ flexGrow: 1 }}>
                                             {description}
                                         </Box>

--- a/public/free/markdown/features/pwa.md
+++ b/public/free/markdown/features/pwa.md
@@ -7,5 +7,9 @@ icon: features
 tags: features, pwa
 ---
 
-> [CleverText text="A Progressive Web App (PWA) is a web application that uses modern browser features to deliver a fast, reliable, app-like experience across devices, including offline access and installability."]
+> [CleverText text="Installable on any phone"]
+
+Progressive Web Apps (PWAs) are installable web applications, Installable on any phone. No app store required. This means you can bypass app store rules and restrictions, while still offering users a seamless, app-like experience. PWAs leverage service workers for caching, offline access, and fast performance, making them reliable and accessible anywhere.
+
+PWAs have been around since 2015 and are now a mature, widely adopted technology. Major companies and countless developers use PWAs to deliver robust, high-quality experiences across devices. Their proven track record makes them a reliable standard for modern web applications.
 

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -7,6 +7,8 @@ tags: NX, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, Reac
 icon: goldlabel
 ---
 [PageLink icon="prospects" title="Prospects™" description="Example App" url="/apps/prospects"]  
+[PageLink icon="features" title="Design System" url="/features/design-system"]  
+[PageLink icon="features" title="PWA" url="/features/pwa"]  
 [PageLink icon="features" title="Techstack" url="/techstack"]  
 [PageLink icon="features" title="Python" url="/techstack/python"]  
 [PageLink icon="features" title="NextJS" url="/techstack/nextjs"]  


### PR DESCRIPTION
Update PWA docs and site index, and tweak layout spacing. Added expanded content to public/free/markdown/features/pwa.md describing PWA installability, service workers, offline support, and adoption. Added PageLink entries to public/free/markdown/index.md for the Design System and PWA pages. Adjusted icon container in app/[[...slug]]/page.tsx to use horizontal margins (mx: 2) for balanced spacing around the icon.