### PR TITLE
Add Prospects link and update prospect page slug

### DIFF
--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -6,6 +6,7 @@ description: Fullstack Framework
 tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 icon: js
 ---
+[PageLink icon="prospects" title="Prospects™" url="/prospects"]  
 
 #### Features  
 [PageLink icon="design" title="Design System" url="/features/design-system"]  

--- a/public/free/markdown/prospects.md
+++ b/public/free/markdown/prospects.md
@@ -2,7 +2,7 @@
 order: 701
 title: Prospects™
 description: Be more direct
-slug: /apps/prospects
+slug: /prospects
 icon: prospects
 image: /free/png/apps.png
 tags: PWA, fast search, tsvector, python


### PR DESCRIPTION
Add a PageLink for Prospects to the free markdown index and update the Prospects page metadata. The prospects file was renamed from apps/prospects.md to prospects.md and its slug changed from /apps/prospects to /prospects so the page is served at /prospects.