### PR TITLE
Remove top search/filter bar and simplify layout

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -2,13 +2,11 @@
 import type { T_Config } from '../types';
 import * as React from 'react';
 import {
-    useTheme,
+    Typography,
     Container,
     CircularProgress,
     Box,
     Alert,
-    AppBar,
-    Toolbar,
     Grid,
     Pagination,
 } from '@mui/material';
@@ -16,13 +14,11 @@ import {
     useDispatch,
 } from '../Uberedux';
 import {
-    Search,
     useProspects,
     initProspects,
     Result,
     updateQuery,
     searchProspects,
-    ChipSelect,
     normaliseForChipSelect,
     useTable,
 } from '../Prospects';
@@ -39,22 +35,16 @@ export default function Prospects({
     const dispatch = useDispatch();
     const table = useTable();
     const state = useProspects();
-    const theme = useTheme();
     const loading = state?.loading;
     const results = state?.results;
-    const query = state?.query;
     const initialData = state?.initialData;
     const pagination = state?.pagination;
 
-    // Handle page change for pagination
     const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
         dispatch(updateQuery({ page: value }));
         dispatch(searchProspects());
     };
-    
-    const seniorityOptions = normaliseForChipSelect(initialData?.groups?.seniority?.list || [], 'label', 'value');
-    const departmentOptions = normaliseForChipSelect(initialData?.groups?.sub_departments?.list || [], 'label', 'value');
-    
+        
     React.useEffect(() => {
         if (!state) {
             dispatch(initProspects());
@@ -94,15 +84,58 @@ export default function Prospects({
 
     return (
         <>
-            <AppBar position="fixed" sx={{ 
-                background: theme.palette.background.default, 
-                boxShadow:0, 
-                mt: '60px' 
-            }}>
-                <Toolbar>
-                    <Container maxWidth="lg" sx={{ my: 3 }}>
+            <Container maxWidth="lg" sx={{ my: 0 }}>
+                <Box sx={{ 
+                    // mt: '125px',
+                 }}>
+                    {/* Pagination */}
+                    {pagination && pagination.pages > 1 && (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0 }}>
+                            <Pagination
+                                sx={{mb:4}}
+                                size="small"
+                                count={pagination.pages}
+                                page={pagination.page}
+                                onChange={handlePageChange}
+                                color="primary"
+                                shape="rounded"
+                            />
+                        </Box>
+                    )}
 
+                    {Array.isArray(results) && results.length > 0 ? (
                         <Grid container spacing={2}>
+                            {results.map((result, idx) => (
+                                <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
+                                    <Result result={result} autoOpen={idx === 0} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    ) : Array.isArray(table) && table.length > 0 ? (
+                        <Grid container spacing={2}>
+                            {table.map((row, idx) => (
+                                <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
+                                    <Result result={row} autoOpen={idx === 0} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    ) : (
+                        <Box sx={{ textAlign: 'center', color: 'text.secondary', py: 2 }}>
+                            <Typography variant="h6" gutterBottom>
+                                Finding prospects...
+                            </Typography>
+                        </Box>
+                    )}
+                </Box>
+            </Container>
+            {/* <pre>total {JSON.stringify(initialData?.total, null, 2)}</pre> */}
+        </>
+    );
+}
+
+
+/*
+<Grid container spacing={2}>
 
                             <Grid size={{ xs: 12 }}>
                                 <Box sx={{ mx: 1, mt: 1 }}>
@@ -133,54 +166,18 @@ export default function Prospects({
                             
 
                         </Grid>
+
+                                    <AppBar position="fixed" sx={{ 
+                background: theme.palette.background.default, 
+                boxShadow:0, 
+                mt: '60px' 
+            }}>
+                <Toolbar>
+                    <Container maxWidth="lg" sx={{ my: 3 }}>
+
+                        
                     </Container>
                 </Toolbar>
             </AppBar>   
-            
-            <Container maxWidth="lg" sx={{ my: 2 }}>
-                <Box sx={{ mt: '125px' }}>
 
-                    {/* Pagination */}
-                    {pagination && pagination.pages > 1 && (
-                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
-                            <Pagination
-                                sx={{mb:4}}
-                                size="small"
-                                count={pagination.pages}
-                                page={pagination.page}
-                                onChange={handlePageChange}
-                                color="primary"
-                                shape="rounded"
-                            />
-                        </Box>
-                    )}
-
-                    {Array.isArray(results) && results.length > 0 ? (
-                        <Grid container spacing={2}>
-                            {results.map((result, idx) => (
-                                <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
-                                    <Result result={result} autoOpen={idx === 0} />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    ) : Array.isArray(table) && table.length > 0 ? (
-                        <Grid container spacing={2}>
-                            {table.map((row, idx) => (
-                                <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
-                                    <Result result={row} autoOpen={idx === 0} />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    ) : (
-                        <Box sx={{ textAlign: 'center', color: 'text.secondary', py: 8 }}>
-                            Loading prospects...
-                        </Box>
-                    )}
-
-                    
-                </Box>
-            </Container>
-            {/* <pre>total {JSON.stringify(initialData?.total, null, 2)}</pre> */}
-        </>
-    );
-}
+*/


### PR DESCRIPTION
Remove the AppBar search and ChipSelect filters and their related imports/state (Search, ChipSelect, useTheme, query, seniority/department options and normalisation). Simplify container spacing and box margins, reduce loading placeholder padding and update the loading text to "Finding prospects..." with a Typography. Adjust pagination spacing and keep the old UI markup preserved in a commented block at the file bottom for reference.