### PR TITLE
Update prospects endpoints and search params

### DIFF
--- a/app/NX/Prospects/actions/initProspects.tsx
+++ b/app/NX/Prospects/actions/initProspects.tsx
@@ -20,7 +20,7 @@ export const initProspects = () =>
                 table,
             ] = await Promise.all([
                 fetchJson(`${base}prospects/init`),
-                fetchJson(`${base}prospects/read`)
+                fetchJson(`${base}prospects/`)
             ]);
             dispatch(setProspects('initialData', initial?.data));
             dispatch(setProspects('table', table?.data));

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -10,7 +10,12 @@ export const searchProspects = () => async (
     dispatch(setProspects('searching', true));
     try {
         dispatch(setProspects('searching', true));
-        const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects/search/?query=${encodeURIComponent(getState().redux.prospects?.query?.search)}`;
+        const state = getState().redux.prospects;
+        const page = state?.query?.page || 1;
+        const limit = state?.query?.limit || 50;
+        // Optionally add search param if needed in the future
+        // const search = state?.query?.search;
+        const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects?page=${page}&limit=${limit}`;
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);
         const data = await res.json();
@@ -25,11 +30,6 @@ export const searchProspects = () => async (
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         dispatch(setUbereduxKey({ key: 'error', value: msg }));
-        // dispatch(setFeedback({
-        //     severity: 'error',
-        //     title: 'searchProspects Exception',
-        //     description: msg,
-        // }));
         dispatch(setProspects('searching', false));
     }
 };


### PR DESCRIPTION
Change initProspects to fetch the table from 'prospects/' instead of 'prospects/read'. Revise searchProspects to construct the endpoint using page and limit from redux state (defaults: page=1, limit=50), remove the encoded search query from the URL while leaving a commented placeholder for future search params, and simplify error handling by removing the commented feedback dispatch.