### PR TITLE
Rename sendPrompt to rateProspect, add Auto Rate

### DIFF
--- a/app/NX/Prospects/README.md
+++ b/app/NX/Prospects/README.md
@@ -1,4 +1,4 @@
-## Prospects™
+## Prospects°
 
 As a user I want to identify a single prospect to 
 focus on. The goal is to be as quick and accurate as possible 

--- a/app/NX/Prospects/actions/rateProspect.tsx
+++ b/app/NX/Prospects/actions/rateProspect.tsx
@@ -1,8 +1,12 @@
+
 import type { T_UbereduxDispatch } from '../../types';
+import type { T_ApolloDoc } from '../types'
 import { setUbereduxKey } from '../../Uberedux';
 import { setProspects } from '../../Prospects';
 
-export const sendPrompt = (prompt: string) =>
+export const rateProspect = (
+    prospect: T_ApolloDoc
+) =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
             const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prompts`;
@@ -10,11 +14,10 @@ export const sendPrompt = (prompt: string) =>
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
-                const base = process.env.NEXT_PUBLIC_NX_AI;
-                msg = `Can't reach NX-AI at ${base}`;
+                const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prompts`;
+                msg = `Can't fetch endpoint ${endpoint}`;
             }
             dispatch(setProspects('error', msg));
-            dispatch(setProspects('completion', false));
             dispatch(setUbereduxKey({ key: 'error', value: msg }));
         }
     };

--- a/app/NX/Prospects/components/Prompt.tsx
+++ b/app/NX/Prospects/components/Prompt.tsx
@@ -8,9 +8,9 @@ import {
     Button,
 } from "@mui/material";
 import { useDispatch } from '../../Uberedux';
-import { 
-    sendPrompt,
-} from '../../Prospects';
+// import { 
+//     sendPrompt,
+// } from '../../Prospects';
 import {Icon} from '../../DesignSystem';
 import { promptMagentoPlugin } from '../../Prospects'
 
@@ -59,7 +59,7 @@ export default function Prompt({ result }: I_Prompt) {
                 color="primary"
                 startIcon={<Icon icon="linkedin" />}
                 onClick={() => {
-                    dispatch(sendPrompt(prompt));
+                    // dispatch(sendPrompt(prompt));
                 }}>
                 Who is?
             </Button>
@@ -69,7 +69,7 @@ export default function Prompt({ result }: I_Prompt) {
                     color="primary" 
                     startIcon={<Icon icon="email" />}
                     onClick={() => {
-                        dispatch(sendPrompt(prompt));
+                        // dispatch(sendPrompt(prompt));
                     }}>
                     Write email
                 </Button>

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { I_Result } from '../types';
+import type { I_Result, T_ApolloDoc } from '../types';
 import {
     IconButton,
     Tooltip,
@@ -34,8 +34,8 @@ import {
     hideProspect,
     flagProspect,
     Prompt,
-    WhoIs,
     useProspects,
+    rateProspect,
 } from '../../Prospects'
 
 
@@ -71,10 +71,19 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const hostname = emailToHostname(result.email as string);
     const prospects = useProspects();
     const flagging = prospects?.flagging;
-    // console.log("flagging", flagging);
 
     const handleResultClick = () =>  setOpen(true);
     const handleClose = () => setOpen(false);
+
+    const handleAutoRate = () => {
+        dispatch(rateProspect(result as T_ApolloDoc));
+    };
+
+    const handleEmail = () => {
+        console.log("Email clicked for", result.first_name, result.last_name);  
+        // dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} hidden`));
+        // handleClose();
+    }
     
     const handleHide = () => {
         dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} hidden`));
@@ -222,13 +231,20 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 <DialogActions>
                     <Button
                         fullWidth
-                        variant="contained"
+                        variant="outlined"
                         color="primary"
-                        startIcon={<Icon icon="stalk" />}
-                        onClick={() => {
-                            // dispatch(sendWhoIs(prompt));
-                        }}>
-                        Stalk
+                        startIcon={<Icon icon="star" />}
+                        onClick={handleAutoRate}>
+                        Auto Rate
+                    </Button>
+                    <Button
+                        disabled
+                        fullWidth
+                        variant="outlined"
+                        color="primary"
+                        startIcon={<Icon icon="email" />}
+                        onClick={handleEmail}>
+                        Email
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -17,7 +17,7 @@ import { useProspects } from './hooks/useProspects';
 import { useTable } from './hooks/useTable';
 import { promptMagentoPlugin, stalkPrompt } from './lib/prompts';
 import { normaliseForChipSelect } from './lib/normalise';
-import { sendPrompt } from './actions/sendPrompt';
+import { rateProspect } from './actions/rateProspect';
 import { flagProspect } from './actions/flagProspect';
 import { hideProspect } from './actions/hideProspect';
 
@@ -40,10 +40,9 @@ export {
     resetQuery,
     addToBasket,
     normaliseForChipSelect,
-    sendPrompt,
+    rateProspect,
     promptMagentoPlugin,
     flagProspect,
     hideProspect,
-
     stalkPrompt,
 };

--- a/public/free/markdown/techstack/python-3.md
+++ b/public/free/markdown/techstack/python-3.md
@@ -11,7 +11,7 @@ icon: techstack
 A modern Python backend built with **FastAPI**, providing high performance and easy-to-use APIs. The app is deployed on [Render](https://render.com/), ensuring reliable and scalable hosting. For data storage, we use **Postgres** as our primary database. This combination ensures a robust, production-ready, and open-source solution optimized for speed and reliability
 
 [PageLink icon="github" title="Python" description="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
-[PageLink icon="doc" title="Swagger" description="nx-ai.onrender.com/docs" url="https://nx-ai.onrender.com/docs"]  
+[PageLink icon="doc" title="redoc" description="Auto-generateg interactive docs" url="https://nx-ai.onrender.com/redoc"]  
 
 A crucial and distinctive feature of our stack is the use of the **tsvector** data type in Postgres. By utilizing tsvector for full-text search, our application achieves superfast and efficient search capabilities, even with large datasets. 
 This enables users to experience near-instantaneous search results, 


### PR DESCRIPTION
Rename the sendPrompt action to rateProspect and update its signature to accept a T_ApolloDoc. Improve error handling message to include the resolved endpoint and remove an unnecessary completion dispatch. Update imports/exports to use rateProspect. In Result.tsx, add types and import rateProspect, add handleAutoRate (dispatches rateProspect) and a placeholder handleEmail, adjust dialog buttons (outlined variant, add Auto Rate button with star icon, enable Email button with email icon) and remove the WhoIs usage. Minor content tweaks: Prospects README header symbol changed and a public markdown link updated from Swagger to Redoc.