### PR TITLE
Add LLM rating flow for prospects

### DIFF
--- a/app/NX/Prospects/actions/rateProspect.tsx
+++ b/app/NX/Prospects/actions/rateProspect.tsx
@@ -3,14 +3,37 @@ import type { T_UbereduxDispatch } from '../../types';
 import type { T_ApolloDoc } from '../types'
 import { setUbereduxKey } from '../../Uberedux';
 import { setProspects } from '../../Prospects';
+import { stalkPrompt } from '../lib/prompts';
 
 export const rateProspect = (
     prospect: T_ApolloDoc
 ) =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
-            const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prompts`;
-            console.log('Sending prompt to:', endpoint);
+            const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}llm`;
+
+            dispatch(setProspects('ratingProspect', true));
+            const prompt = stalkPrompt(prospect);
+            const payload = {
+                prompt,
+            };
+
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data = await response.json();
+            dispatch(setProspects('rating', data));
+            dispatch(setProspects('ratingProspect', false));
+
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -71,6 +71,11 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const hostname = emailToHostname(result.email as string);
     const prospects = useProspects();
     const flagging = prospects?.flagging;
+    const rating = prospects?.rating;
+    const ratingProspect = prospects?.ratingProspect;
+    
+    // console.log('ratingProspect', ratingProspect);
+    // console.log('rating', rating);
 
     const handleResultClick = () =>  setOpen(true);
     const handleClose = () => setOpen(false);
@@ -80,9 +85,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     };
 
     const handleEmail = () => {
-        console.log("Email clicked for", result.first_name, result.last_name);  
-        // dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} hidden`));
-        // handleClose();
+        console.log("Email clicked for", result.first_name, result.last_name);
     }
     
     const handleHide = () => {
@@ -227,9 +230,11 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                             </List>
                         </Grid>
                     </Grid>
+                    {/* <pre>{JSON.stringify(rating, null, 2)}</pre> */}
                 </DialogContent>
                 <DialogActions>
                     <Button
+                        disabled
                         fullWidth
                         variant="outlined"
                         color="primary"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "scripts": {
     "dev": "yarn kill && yarn install && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",


### PR DESCRIPTION
Integrate an LLM-based rating flow: rateProspect now builds a prompt (stalkPrompt), posts JSON to NEXT_PUBLIC_NX_AI + 'llm', handles HTTP errors, parses the response, and dispatches 'rating' and 'ratingProspect' flags during the request. Result component reads prospects.rating and prospects.ratingProspect, includes small UI/debug tweaks (disabled action button and minor console log cleanup). Also bump package version to 2.1.5.