### PR TITLE
Add .env.example and whitelist it in .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+###############################
+# Example .env file
+# Copy this file to .env and fill in your real credentials
+###############################
+
+NEXT_PUBLIC_TENANT="your-tenant-name"
+NEXT_PUBLIC_NX_AI="http://localhost:8000/"
+FIREBASE_PROJECT_ID="your-firebase-project-id"
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-firebase-auth-domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-firebase-app-id
+FIREBASE_CLIENT_EMAIL="your-firebase-client-email"
+RESEND_API_KEY=your-resend-api-key
+FLICKR_USER=your-flickr-user
+FLICKR_KEY=your-flickr-key
+FLICKR_SECRET=your-flickr-secret
+OPENAI_API_KEY=your-openai-api-key
+NEXT_PUBLIC_IPGEOLOCATION_API_KEY=your-ipgeolocation-api-key
+NEXT_PUBLIC_MAPBOX_TOKEN=your-mapbox-token
+FIREBASE_SERVICE_ACCOUNT_KEY='{"type":"service_account","project_id":"your-firebase-project-id","private_key_id":"your-private-key-id","private_key":"-----BEGIN PRIVATE KEY-----\nyour-private-key\n-----END PRIVATE KEY-----\n","client_email":"your-firebase-client-email","client_id":"your-client-id","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/your-firebase-client-email","universe_domain":"googleapis.com"}'

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Add a .env.example template containing placeholder environment variables (NEXT_PUBLIC_*, FIREBASE_*, OPENAI_API_KEY, MAPBOX token, etc.) including a sample FIREBASE_SERVICE_ACCOUNT_KEY JSON. Update .gitignore to keep ignoring .env* while allowing .env.example so the example file can be committed and shared with collaborators.