### PR TITLE
Rebrand free tenant to NX° and add Edtech link

### DIFF
--- a/public/free/config.json
+++ b/public/free/config.json
@@ -1,11 +1,11 @@
 {
     "tenant": "free",
-    "siteName": "NX",
+    "siteName": "NX°",
     "description": "Open Source & Free",
     "url": "https://goldlabel.pro",
     "owner": {
-        "name": "Chris",
-        "email": "goldlabel.apps@gmail.com"
+        "name": "NX°",
+        "email": "nx@goldlabel.pro"
     },
     "favicon": "/free/svg/favicon.svg",
     "avatars": {

--- a/public/free/manifest.json
+++ b/public/free/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "NX",
-  "name": "NX",
+  "short_name": "NX°",
+  "name": "NX°",
   "theme_color": "#364450",
   "background_color": "#364450",
   "display": "fullscreen",

--- a/public/free/markdown/apps/index.md
+++ b/public/free/markdown/apps/index.md
@@ -6,8 +6,9 @@ slug: /apps
 icon: mobile
 tags: tenants, apps,
 ---
+[PageLink icon="doc" title="Edtech°" description="Educational Technology" url="https://ed-tech.co/"]  
 [PageLink icon="food" title="Food°" url="/apps/food" description="Bladdy give it some"]  
 [PageLink icon="prospects" title="Prospects°" url="/apps/prospects" description="Be more direct"]  
 [PageLink icon="orders" title="Orders°" url="/apps/orders" description="Easy Ecommerce"]  
 [PageLink icon="virus" title="Virus°" url="/apps/virus" description="Share the love"]  
-[PageLink icon="doc" title="Edtech°" description="Educational Technology" url="https://ed-tech.co/"]  
+

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -1,7 +1,7 @@
 ---
 order: 1 
 slug: /
-title: NX
+title: NX°
 tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 ---
 


### PR DESCRIPTION
Update branding and contact for the 'free' tenant: change siteName and owner (name/email) in public/free/config.json, update name/short_name in public/free/manifest.json, and change the homepage title in public/free/markdown/index.md to NX°. Also tidy apps list in public/free/markdown/apps/index.md by adding the Edtech PageLink at the top and removing a duplicate entry.