### PR TITLE
Remove Home IconButton from Nav drawer

### DIFF
--- a/app/NX/DesignSystem/components/Nav.tsx
+++ b/app/NX/DesignSystem/components/Nav.tsx
@@ -165,14 +165,6 @@ const Nav: React.FC<I_Nav> = ({
                                 </IconButton>
                             </Box>
                             
-                            <Box sx={{ ml: 1 }}>
-                                <IconButton
-                                    color="primary"
-                                    onClick={handleHomeClick}>
-                                    <Icon icon={'home'} />
-                                </IconButton>
-                            </Box>
-
                         </Box>
                     </Box>
                 </Drawer>

--- a/app/NX/DesignSystem/components/Nav.tsx
+++ b/app/NX/DesignSystem/components/Nav.tsx
@@ -61,10 +61,10 @@ const Nav: React.FC<I_Nav> = ({
         }
     }
 
-    function handleHomeClick() {
-            dispatch(navigateTo(router, '/'));
-            setDrawerOpen(false);
-    }
+    // function handleHomeClick() {
+    //         dispatch(navigateTo(router, '/'));
+    //         setDrawerOpen(false);
+    // }
 
     function handleGithubClick() {
         dispatch(navigateTo(router, '/techstack/git'));
@@ -144,9 +144,7 @@ const Nav: React.FC<I_Nav> = ({
                         <TreeNav navItems={navItems}/>
                         <Box sx={{ mt: 'auto', display: 'flex' }}>
                             
-                            <Box sx={{ mt: 1, ml: 2 }}>
-                                <NavVirus frontmatter={frontmatter} />
-                            </Box>
+                            
 
                             {themeSwitching && <>
                                 <Box sx={{ pb: 1.5, ml:2 }}>
@@ -156,14 +154,17 @@ const Nav: React.FC<I_Nav> = ({
                                 </Box>
                             </>}
                             
+                            <Box sx={{ mt: 1, ml: 2 }}>
+                                <NavVirus frontmatter={frontmatter} />
+                            </Box>
                             
-                            <Box sx={{ ml: 1 }}>
+                            {/* <Box sx={{ ml: 1 }}>
                                 <IconButton
                                     color="primary"
                                     onClick={handleGithubClick}>
                                     <Icon icon={'github'} />
                                 </IconButton>
-                            </Box>
+                            </Box> */}
                             
                         </Box>
                     </Box>

--- a/public/free/markdown/apps/index.md
+++ b/public/free/markdown/apps/index.md
@@ -8,7 +8,6 @@ tags: tenants, apps,
 ---
 [PageLink icon="doc" title="Edtech°" description="Educational Technology" url="https://ed-tech.co/"]  
 [PageLink icon="food" title="Food°" url="/apps/food" description="Bladdy give it some"]  
-[PageLink icon="prospects" title="Prospects°" url="/apps/prospects" description="Be more direct"]  
+[PageLink icon="prospects" title="Prospects°" url="/prospects" description="Be more direct"]  
 [PageLink icon="orders" title="Orders°" url="/apps/orders" description="Easy Ecommerce"]  
 [PageLink icon="virus" title="Virus°" url="/apps/virus" description="Share the love"]  
-


### PR DESCRIPTION
Remove the Box wrapper and IconButton that rendered the home icon inside the Nav component's Drawer. This cleans up the navigation UI by removing the home shortcut button; review and remove any now-unused handler or imports (e.g., handleHomeClick) if necessary.