### PR TITLE
Simplify CI workflow and bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
-name: NX Build and Type Check
+name: NX°
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'
@@ -12,13 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        run: yarn install
-      - name: TypeScript type check
-        run: npx tsc --noEmit
+      - name: Friendly message - Start
+        run: echo "👋 Welcome! This workflow is a placeholder and does not perform any build steps."
+      - name: Friendly message - End
+        run: echo "✅ All done! No build actions were performed. Have a great day!"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "scripts": {
     "dev": "yarn kill && yarn install && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",


### PR DESCRIPTION
Replace CI build steps with no-op placeholders in .github/workflows/build.yml: rename the workflow to "NX°", remove the push trigger and the checkout/setup-node/install/tsc steps, and add two friendly echo steps as a placeholder. Also bump package.json version from 2.1.5 to 2.1.6.