### PR TITLE
Add nhtfs app page and index link

### DIFF
--- a/public/free/markdown/apps/nhtfs.md
+++ b/public/free/markdown/apps/nhtfs.md
@@ -1,0 +1,12 @@
+---
+order: 901
+title: 魏魏°
+description: 我不是来和蜘蛛交配的
+slug: /apps/nhtfs
+icon: writing
+tags: nhtfs, writing, wei zang,
+image: https://live.staticflickr.com/65535/54338019655_94e8e39903_b.jpg
+---
+> [CleverText text="Not here to fuck spiders. By Wei Zang"]
+
+[PageLink icon="writing" title="魏魏°" description="我不是来和蜘蛛交配的" url="https://nhtfs.goldlabel.pro"]  

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -9,6 +9,8 @@ tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaSc
 
 [PageLink icon="features" title="Features" description="Powerful modern technologies" url="/features"]  
 
-[PageLink icon="techstack" title="Techstack" description="Fullstack Framework " url="/techstack"]  
+[PageLink icon="techstack" title="Techstack" description="Fullstack Framework" url="/techstack"]  
+
+[PageLink icon="writing" title="魏魏°" description="我不是来和蜘蛛交配的" url="/apps/nhtfs"]  
 
 NX is a modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.


### PR DESCRIPTION
Create a new markdown page for the nhtfs app (public/free/markdown/apps/nhtfs.md) with metadata (title: 魏魏°, slug: /apps/nhtfs, tags, image) and a PageLink to the external site. Also add a corresponding PageLink entry to public/free/markdown/index.md and trim a trailing space from the Techstack description.