### PR TITLE
Add per-prospect AI rating UI & refactor state

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -57,6 +57,9 @@ export default function Prospects({
                     dispatch(updateQuery({ search: searchParam }));
                     dispatch(searchProspects());
                 }, 333);
+            } else {
+                // No search param, load page 1 of unmodified query
+                dispatch(searchProspects());
             }
         }
     }, [state, dispatch]);
@@ -104,6 +107,7 @@ export default function Prospects({
                     {/* Pagination */}
 
                     <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 2}}>
+                        <Search label="Search" />
                         {pagination && pagination.pages > 1 && (
                             <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0 }}>
                                 <Pagination
@@ -117,7 +121,7 @@ export default function Prospects({
                                 />
                             </Box>
                         )}
-                        <Search label="Search" />
+                        
                     </Box>
 
                     

--- a/app/NX/Prospects/actions/rateProspect.tsx
+++ b/app/NX/Prospects/actions/rateProspect.tsx
@@ -1,4 +1,3 @@
-
 import type { T_UbereduxDispatch } from '../../types';
 import type { T_ApolloDoc } from '../types'
 import { setUbereduxKey } from '../../Uberedux';
@@ -11,13 +10,14 @@ export const rateProspect = (
     async (dispatch: T_UbereduxDispatch) => {
         try {
             const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}llm`;
-
-            dispatch(setProspects('ratingProspect', true));
+            dispatch((dispatch, getState) => {
+                const current = getState().redux.prospects?.isRating || {};
+                dispatch(setProspects('isRating', { ...current, [prospect.id]: true }));
+            });
             const prompt = stalkPrompt(prospect);
             const payload = {
                 prompt,
             };
-
             const response = await fetch(endpoint, {
                 method: 'POST',
                 headers: {
@@ -25,21 +25,33 @@ export const rateProspect = (
                 },
                 body: JSON.stringify(payload),
             });
-
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
-
             const data = await response.json();
-            dispatch(setProspects('rating', data));
-            dispatch(setProspects('ratingProspect', false));
+            dispatch((dispatch, getState) => {
+                const current = getState().redux.prospects?.ratings || {};
+                dispatch(setProspects('ratings', { ...current, [prospect.id]: data }));
+            });
+            dispatch((dispatch, getState) => {
+                const current = getState().redux.prospects?.isRating || {};
+                const updated = { ...current };
+                delete updated[prospect.id];
+                dispatch(setProspects('isRating', updated));
+            });
 
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
                 const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prompts`;
                 msg = `Can't fetch endpoint ${endpoint}`;
-            }
+            };
+            dispatch((dispatch, getState) => {
+                const current = getState().redux.prospects?.isRating || {};
+                const updated = { ...current };
+                delete updated[prospect.id];
+                dispatch(setProspects('isRating', updated));
+            });
             dispatch(setProspects('error', msg));
             dispatch(setUbereduxKey({ key: 'error', value: msg }));
         }

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -20,6 +20,7 @@ import {
     ListItemButton,
     ListItemText,
     ListItemIcon,
+    LinearProgress,
     Grid,
 } from '@mui/material';
 import {useRouter} from 'next/navigation';
@@ -33,7 +34,6 @@ import {
 import {
     hideProspect,
     flagProspect,
-    Prompt,
     useProspects,
     rateProspect,
 } from '../../Prospects'
@@ -71,7 +71,21 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const hostname = emailToHostname(result.email as string);
     const prospects = useProspects();
     const flagging = prospects?.flagging;
-    const rating = prospects?.rating;
+    const ratings = prospects?.ratings || {};
+    const isRatingMap = prospects?.isRating || {};
+    const isRating = !!isRatingMap[result.id];
+    const rating = ratings[result.id];
+    let parsedCompletion = null;
+    if (rating && rating.data && rating.data.completion) {
+        try {
+            parsedCompletion = JSON.parse(rating.data.completion);
+            // eslint-disable-next-line no-console
+            // console.log('Parsed completion:', parsedCompletion);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            // console.error('Failed to parse completion JSON:', e, rating.data.completion);
+        }
+    }
     const ratingProspect = prospects?.ratingProspect;
     
     // console.log('ratingProspect', ratingProspect);
@@ -230,26 +244,53 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                             </List>
                         </Grid>
                     </Grid>
-                    {/* <pre>{JSON.stringify(rating, null, 2)}</pre> */}
+
+
+                    {isRating && (
+                        <Box sx={{ my: 2 }}>
+                            <Typography variant="body2" sx={{ mb: 1, textAlign: 'center' }} color="primary">
+                                Analysing this prospect with AI... Please wait for a commercial summary and score.
+                            </Typography>
+                            <Box sx={{ width: '100%' }}>
+                                <LinearProgress color="primary" />
+                            </Box>
+                        </Box>
+                    )}
+{/*                     
+                    <pre>rating?: {JSON.stringify(ratingProspect, null, 2)}</pre>
+                    <pre>parsedCompletion: {JSON.stringify(parsedCompletion, null, 2)}</pre> */}
+                    {parsedCompletion && (
+                        <Box>
+                            <Typography variant="subtitle1">Prospect Analysis</Typography>
+
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Prospect Score:</b> {parsedCompletion.prospect_score}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Prospect Grade:</b> {parsedCompletion.prospect_grade}</Typography>
+
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Seniority Level:</b> {parsedCompletion.seniority_level}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Decision Power:</b> {parsedCompletion.decision_power}</Typography>
+                            
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Recommendation:</b> {parsedCompletion.recommendation}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Summary:</b> {parsedCompletion.summary}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Role Inference:</b> {parsedCompletion.role_inference}</Typography>
+                            
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Key Priorities:</b> {parsedCompletion.key_priorities && parsedCompletion.key_priorities.length > 0 ? parsedCompletion.key_priorities.join(', ') : 'N/A'}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Likely Pain Points:</b> {parsedCompletion.likely_pain_points && parsedCompletion.likely_pain_points.length > 0 ? parsedCompletion.likely_pain_points.join(', ') : 'N/A'}</Typography>
+                            <Typography variant="body2" sx={{ mb: 1 }}><b>Intent Alignment:</b> {parsedCompletion.intent_alignment}</Typography>
+                        </Box>
+                    )}
+
+
                 </DialogContent>
                 <DialogActions>
                     <Button
-                        disabled
                         fullWidth
-                        variant="outlined"
+                        variant="contained"
                         color="primary"
                         startIcon={<Icon icon="star" />}
-                        onClick={handleAutoRate}>
-                        Auto Rate
-                    </Button>
-                    <Button
-                        disabled
-                        fullWidth
-                        variant="outlined"
-                        color="primary"
-                        startIcon={<Icon icon="email" />}
-                        onClick={handleEmail}>
-                        Email
+                        onClick={handleAutoRate}
+                        disabled={isRating}
+                    >
+                        Auto Analyse
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -5,12 +5,12 @@ title: NX°
 tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 ---
 
-[PageLink icon="mobile" title="Apps°" description="Tenants in the wild" url="/apps"]  
+[PageLink icon="mobile" title="Apps°" description="Tenants in the wild" url="/tenants"]  
 
 [PageLink icon="features" title="Features" description="Powerful modern technologies" url="/features"]  
 
 [PageLink icon="techstack" title="Techstack" description="Fullstack Framework" url="/techstack"]  
 
-[PageLink icon="writing" title="魏魏°" description="我不是来和蜘蛛交配的" url="/apps/nhtfs"]  
+[PageLink icon="writing" title="魏魏°" description="我不是来和蜘蛛交配的" url="/tenants/nhtfs"]  
 
 NX is a modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.

--- a/public/free/markdown/prospects.md
+++ b/public/free/markdown/prospects.md
@@ -1,5 +1,5 @@
 ---
-order: 701
+order: 2
 title: Prospects°
 description: Be more direct
 slug: /prospects


### PR DESCRIPTION
Refactor AI rating flow and improve UI/UX across prospects.

- rateProspect: switch to per-prospect maps (ratings, isRating) using getState so multiple ratings can run concurrently; set/clear isRating on start/finish and on errors; preserve existing error handling.
- Result component: show LinearProgress and an "Analysing" message while a prospect is being rated; parse AI completion JSON and render summary fields (score, grade, seniority, recommendation, key priorities, etc.); change action button to "Auto Analyse" and disable it while rating.
- Prospects.tsx: ensure searchProspects is dispatched when no search param and move the Search input into the pagination/layout block (remove duplicate placement).
- Docs: update public/free/markdown links (use /tenants paths) and adjust prospects page order.

These changes improve concurrent rating state management and provide clearer feedback to users during AI analysis.