### PR TITLE
Add bottom margin; remove Prospects config prop

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -106,7 +106,7 @@ export default function Prospects({
                  }}>
                     {/* Pagination */}
 
-                    <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 2}}>
+                    <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 2, mb: 2}}>
                         <Search label="Search" />
                         {pagination && pagination.pages > 1 && (
                             <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0 }}>

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -131,7 +131,7 @@ export default async function Page(props: any) {
                     ) : data.cartridge === 'prospects' ? (
                         <Container id="main" maxWidth="lg" sx={{ mt: '100px', pb: '90px' }}>
                             <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}>
-                                <Prospects config={config}/>
+                                <Prospects />
                             </Box>
                         </Container>
                     ) : (


### PR DESCRIPTION
Add a bottom margin (mb: 2) to the pagination container Box in Prospects.tsx to improve spacing. Also remove the now-unused config prop when rendering <Prospects /> in page.tsx so the call site matches the component's expected props.