### PR TITLE
This pull request introduces a minor update to the `rateProspect` action. The change ensures that the `prospect_id` is explicitly included in the payload sent to the endpoint, which can help the backend identify the prospect being rated.

### DIFF
--- a/app/NX/Prospects/actions/rateProspect.tsx
+++ b/app/NX/Prospects/actions/rateProspect.tsx
@@ -16,6 +16,7 @@ export const rateProspect = (
             });
             const prompt = stalkPrompt(prospect);
             const payload = {
+                prospect_id: prospect.id,
                 prompt,
             };
             const response = await fetch(endpoint, {

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -153,7 +153,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 <DialogTitle>
                     <CardHeader 
                         sx={{mx:-2}}
-                        title={`${result.first_name} ${result.last_name} ${result.id}`}
+                        title={`${result.first_name} ${result.last_name}`}
                         subheader={result.title}
                         action={<>
                             <IconButton

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -153,7 +153,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 <DialogTitle>
                     <CardHeader 
                         sx={{mx:-2}}
-                        title={`${result.first_name} ${result.last_name}`}
+                        title={`${result.first_name} ${result.last_name} ${result.id}`}
                         subheader={result.title}
                         action={<>
                             <IconButton


### PR DESCRIPTION


- Added `prospect_id` to the payload object in the `rateProspect` action to ensure the backend receives the correct identifier.