### PR TITLE
Replace NEXT_PUBLIC_NX_AI with NEXT_PUBLIC_PYTHON_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 ###############################
 
 NEXT_PUBLIC_TENANT="your-tenant-name"
-NEXT_PUBLIC_NX_AI="http://localhost:8000/"
+NEXT_PUBLIC_PYTHON_URL="http://localhost:8000/"
+NEXT_PUBLIC_PYTHON_KEY=xxx-1234567890-xxx
 FIREBASE_PROJECT_ID="your-firebase-project-id"
 NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-firebase-auth-domain

--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -1,5 +1,4 @@
 'use client';
-import type { T_Config } from '../types';
 import * as React from 'react';
 import {
     Button,
@@ -17,8 +16,8 @@ import {
 import {
     Icon,
 } from '../DesignSystem';
-import Search from './components/Search';
 import {
+    HammerMenu,
     useProspects,
     initProspects,
     Result,
@@ -84,7 +83,7 @@ export default function Prospects({
                     action={
                         <Button
                             startIcon={<Icon icon="reset" />}
-                            variant="outlined"
+                            variant="contained"
                             color="primary"
                             onClick={() => window.location.reload()}
                         >
@@ -100,57 +99,45 @@ export default function Prospects({
 
     return (
         <>
-            <Container maxWidth="lg" sx={{ my: 0 }}>
-                <Box sx={{ 
-                    // mt: '125px',
-                 }}>
-                    {/* Pagination */}
-
-                    <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 2, mb: 2}}>
-                        <Search label="Search" />
-                        {pagination && pagination.pages > 1 && (
-                            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0 }}>
-                                <Pagination
-                                    sx={{ mb: 4 }}
-                                    size="small"
-                                    count={pagination.pages}
-                                    page={pagination.page}
-                                    onChange={handlePageChange}
-                                    color="primary"
-                                    shape="rounded"
-                                />
-                            </Box>
-                        )}
-                        
-                    </Box>
-
-                    
-                    {Array.isArray(results) && results.length > 0 ? (
-                        <Grid container spacing={2}>
-                            {results.map((result, idx) => (
-                                <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
-                                    <Result result={result} autoOpen={idx === 0} />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    ) : Array.isArray(table) && table.length > 0 ? (
-                        <Grid container spacing={2}>
-                            {table.map((row, idx) => (
-                                <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
-                                    <Result result={row} autoOpen={idx === 0} />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    ) : (
-                        <Box sx={{ textAlign: 'center', color: 'text.secondary', py: 2 }}>
-                            <Typography variant="h6" gutterBottom>
-                                Finding prospects...
-                            </Typography>
-                        </Box>
+            <Container maxWidth="lg">
+                <Box sx={{display: 'flex', mb: 2}}>
+                    {pagination && pagination.pages > 1 && (
+                        <Pagination
+                            sx={{mt:1}}
+                            count={pagination.pages}
+                            page={pagination.page}
+                            onChange={handlePageChange}
+                            color="primary"
+                            shape="rounded"
+                        />
                     )}
+                    <Box sx={{ flexGrow: 1 }} />
+                    <HammerMenu />
                 </Box>
+                {Array.isArray(results) && results.length > 0 ? (
+                    <Grid container spacing={2}>
+                        {results.map((result, idx) => (
+                            <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
+                                <Result result={result} autoOpen={idx === 0} />
+                            </Grid>
+                        ))}
+                    </Grid>
+                ) : Array.isArray(table) && table.length > 0 ? (
+                    <Grid container spacing={2}>
+                        {table.map((row, idx) => (
+                            <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
+                                <Result result={row} autoOpen={idx === 0} />
+                            </Grid>
+                        ))}
+                    </Grid>
+                ) : (
+                    <Box>
+                        <Typography variant="body1">
+                            Loading prospects...
+                        </Typography>
+                    </Box>
+                )}
             </Container>
-            {/* <pre>total {JSON.stringify(initialData?.total, null, 2)}</pre> */}
         </>
     );
 }

--- a/app/NX/Prospects/actions/flagProspect.tsx
+++ b/app/NX/Prospects/actions/flagProspect.tsx
@@ -21,7 +21,7 @@ export const flagProspect = (
 ) =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
-            const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects/${id}`;
+            const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects/${id}`;
             dispatch(setProspects('flagging', true));
             await patchJson(endpoint, { flag });
             dispatch(searchProspects());

--- a/app/NX/Prospects/actions/hideProspect.tsx
+++ b/app/NX/Prospects/actions/hideProspect.tsx
@@ -20,7 +20,7 @@ export const hideProspect = (
 ) =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
-            const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects/${id}`;
+            const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects/${id}`;
             await patchJson(endpoint, { hide });
             dispatch(searchProspects());
             dispatch(setFeedback({ 

--- a/app/NX/Prospects/actions/initProspects.tsx
+++ b/app/NX/Prospects/actions/initProspects.tsx
@@ -13,7 +13,7 @@ export const initProspects = () =>
     async (dispatch: T_UbereduxDispatch) => {
         dispatch(setProspects('loading', true));
         try {
-            const base = process.env.NEXT_PUBLIC_NX_AI;
+            const base = process.env.NEXT_PUBLIC_PYTHON_URL;
             const [
                 health,
             ] = await Promise.all([
@@ -25,7 +25,7 @@ export const initProspects = () =>
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
-                const base = process.env.NEXT_PUBLIC_NX_AI;
+                const base = process.env.NEXT_PUBLIC_PYTHON_URL;
                 msg = `Can't reach Python at ${base}`;
             }
             dispatch(setProspects('error', msg));

--- a/app/NX/Prospects/actions/rateProspect.tsx
+++ b/app/NX/Prospects/actions/rateProspect.tsx
@@ -9,7 +9,7 @@ export const rateProspect = (
 ) =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
-            const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}llm`;
+            const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}llm`;
             dispatch((dispatch, getState) => {
                 const current = getState().redux.prospects?.isRating || {};
                 dispatch(setProspects('isRating', { ...current, [prospect.id]: true }));
@@ -44,7 +44,7 @@ export const rateProspect = (
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
-                const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prompts`;
+                const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prompts`;
                 msg = `Can't fetch endpoint ${endpoint}`;
             };
             dispatch((dispatch, getState) => {

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -15,7 +15,7 @@ export const searchProspects = () => async (
         const limit = state?.query?.limit || 50;
         // Optionally add search param if needed in the future
         // const search = state?.query?.search;
-        const endpoint = `${process.env.NEXT_PUBLIC_NX_AI}prospects?page=${page}&limit=${limit}`;
+        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}`;
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);
         const data = await res.json();

--- a/app/NX/Prospects/components/HammerMenu.tsx
+++ b/app/NX/Prospects/components/HammerMenu.tsx
@@ -1,0 +1,57 @@
+'use client';
+import * as React from 'react';
+import {
+    Box,
+    IconButton,
+    Menu,
+    MenuItem,
+    ListItemIcon,
+} from '@mui/material';
+// import { useDispatch } from '../../Uberedux';
+// import { setProspects } from '../../Prospects';
+import {Icon} from '../../DesignSystem';
+
+
+export default function HammerMenu() {
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <Box>
+            <IconButton
+                color="primary"
+                onClick={handleClick}
+            >
+                <Icon icon='settings' />
+            </IconButton>
+            <Menu
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                <MenuItem onClick={handleClose}>
+                    <ListItemIcon sx={{ mr: 1 }}>
+                        <Icon color="primary" icon="flagoff" />
+                    </ListItemIcon>
+                    Reset all flags
+                </MenuItem>
+                <MenuItem onClick={handleClose}>
+                    <ListItemIcon sx={{mr:1}}>
+                        <Icon color="primary" icon="hide" />
+                    </ListItemIcon>
+                    Unhide all hidden
+                </MenuItem>
+            </Menu>
+        </Box>
+    );
+}

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -1,6 +1,7 @@
 import Prospects from './Prospects';
 import Search from './components/Search';
 import Selecta from './components/Selecta';
+import HammerMenu from './components/HammerMenu';
 import Basket from './components/Basket';
 import Result from './components/Result';
 import Prompt from './components/Prompt';
@@ -32,6 +33,7 @@ export {
     Search,
     Selecta,
     Result,
+    HammerMenu,
     ChipSelect,
     Basket,
     Prompt,


### PR DESCRIPTION
Rename environment variable and update API endpoints to target the Python backend. Updated .env.example to add NEXT_PUBLIC_PYTHON_URL and NEXT_PUBLIC_PYTHON_KEY. Modified prospect actions (initProspects, searchProspects, flagProspect, hideProspect, rateProspect) to build endpoints from NEXT_PUBLIC_PYTHON_URL instead of NEXT_PUBLIC_NX_AI and adjusted error messaging accordingly. Note: deployments and local envs must be updated to provide NEXT_PUBLIC_PYTHON_URL (and optionally NEXT_PUBLIC_PYTHON_KEY) to avoid runtime failures.