### PR TITLE
Prospects: UI tweaks, dialog & loading flag

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -112,12 +112,16 @@ export default function Prospects({
                         />
                     )}
                     <Box sx={{ flexGrow: 1 }} />
-                    <HammerMenu />
+                    
+                    <Box sx={{mr:-2}}>
+                        <HammerMenu />
+                    </Box>
                 </Box>
+                
                 {Array.isArray(results) && results.length > 0 ? (
                     <Grid container spacing={2}>
                         {results.map((result, idx) => (
-                            <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
+                            <Grid key={result.id || idx} size={{ xs: 12 }}>
                                 <Result result={result} autoOpen={idx === 0} />
                             </Grid>
                         ))}
@@ -125,7 +129,7 @@ export default function Prospects({
                 ) : Array.isArray(table) && table.length > 0 ? (
                     <Grid container spacing={2}>
                         {table.map((row, idx) => (
-                            <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
+                            <Grid key={row.id || idx} size={{ xs: 12 }}>
                                 <Result result={row} autoOpen={idx === 0} />
                             </Grid>
                         ))}

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -7,14 +7,11 @@ export const searchProspects = () => async (
     dispatch: T_UbereduxDispatch, 
     getState: () => T_RootState,
 ) => {
-    dispatch(setProspects('searching', true));
     try {
-        dispatch(setProspects('searching', true));
+        dispatch(setProspects('loading', true));
         const state = getState().redux.prospects;
         const page = state?.query?.page || 1;
         const limit = state?.query?.limit || 50;
-        // Optionally add search param if needed in the future
-        // const search = state?.query?.search;
         const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}`;
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);
@@ -26,10 +23,10 @@ export const searchProspects = () => async (
             dispatch(setProspects('results', []));
             dispatch(setProspects('pagination', null));
         }
-        dispatch(setProspects('searching', false));
+        dispatch(setProspects('loading', false));
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         dispatch(setUbereduxKey({ key: 'error', value: msg }));
-        dispatch(setProspects('searching', false));
+        dispatch(setProspects('loading', false));
     }
 };

--- a/app/NX/Prospects/components/HammerMenu.tsx
+++ b/app/NX/Prospects/components/HammerMenu.tsx
@@ -6,6 +6,12 @@ import {
     Menu,
     MenuItem,
     ListItemIcon,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
+    Button,
 } from '@mui/material';
 // import { useDispatch } from '../../Uberedux';
 // import { setProspects } from '../../Prospects';
@@ -16,12 +22,33 @@ export default function HammerMenu() {
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
 
+    // Dialog state
+    const [dialogOpen, setDialogOpen] = React.useState(false);
+    const [dialogAction, setDialogAction] = React.useState<'resetFlags' | 'unhideAll' | null>(null);
+
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);
     };
 
     const handleClose = () => {
         setAnchorEl(null);
+    };
+
+    const handleMenuItemClick = (action: 'resetFlags' | 'unhideAll') => {
+        setDialogAction(action);
+        setDialogOpen(true);
+        setAnchorEl(null);
+    };
+
+    const handleDialogClose = () => {
+        setDialogOpen(false);
+        setDialogAction(null);
+    };
+
+    const handleDialogConfirm = () => {
+        // TODO: Perform the action here (reset flags or unhide all)
+        setDialogOpen(false);
+        setDialogAction(null);
     };
 
     return (
@@ -39,19 +66,37 @@ export default function HammerMenu() {
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'right' }}
             >
-                <MenuItem onClick={handleClose}>
+                <MenuItem onClick={() => handleMenuItemClick('resetFlags')}>
                     <ListItemIcon sx={{ mr: 1 }}>
                         <Icon color="primary" icon="flagoff" />
                     </ListItemIcon>
                     Reset all flags
                 </MenuItem>
-                <MenuItem onClick={handleClose}>
+                <MenuItem onClick={() => handleMenuItemClick('unhideAll')}>
                     <ListItemIcon sx={{mr:1}}>
                         <Icon color="primary" icon="hide" />
                     </ListItemIcon>
                     Unhide all hidden
                 </MenuItem>
             </Menu>
+
+            <Dialog
+                open={dialogOpen}
+                onClose={handleDialogClose}
+            >
+                <DialogTitle>Confirm</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        {dialogAction === 'resetFlags' && 'Are you sure you want to reset all flags? This action cannot be undone.'}
+                        {dialogAction === 'unhideAll' && 'Are you sure you want to unhide all hidden items? This action cannot be undone.'}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleDialogClose} color="inherit">Cancel</Button>
+                    <Button endIcon={<Icon icon="tick" />}
+                     onClick={handleDialogConfirm} color="primary" variant="contained">Confirm</Button>
+                </DialogActions>
+            </Dialog>
         </Box>
     );
 }

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -123,16 +123,18 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
     return (
         <>
-            <ButtonBase sx={{mx:1, width: '100%', textAlign: 'left'}} onClick={handleResultClick}>
+            <ButtonBase sx={{mx:2, width: '100%', textAlign: 'left'}} onClick={handleResultClick}>
                 <Box sx={{ pl: 1, width: '100%', borderLeft: `2px solid ${theme.palette.primary.main}` }}>
                     <Box sx={{display: 'flex'}}>
 
-                        <Box sx={{ display: 'block' }}>
+                        <Box sx={{ display: 'block', }}>
                             <Typography variant="body1">
                                 {result.first_name} {result.last_name}
                             </Typography>
-                            <Typography variant="caption">
-                                {result.title} at {result.company_name}
+                            <Typography 
+                                variant="body2"
+                            >
+                                {result.title} at {result.company_name} 
                             </Typography>
                         </Box>
 
@@ -149,38 +151,56 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 maxWidth="sm" 
                 open={open} 
                 onClose={handleClose} 
-                fullScreen={isMobile}>
+                fullScreen={true}>
+
+                <DialogActions>
+                    <IconButton
+                        onClick={handleHide}
+                        color="primary"
+                    >
+                        <Icon icon="delete" />
+                    </IconButton>
+                    {flagging ? (
+                        <IconButton>
+                            <CircularProgress size={24} color="primary" />
+                        </IconButton>
+                    ) : (
+                        <IconButton
+                            onClick={handleFlag}
+                            color="primary"
+                        >
+                            <Icon icon={!!result.flag ? "flagon" : "flagoff"} />
+                        </IconButton>
+                    )}
+                    {/* <Button
+                        variant="contained"
+                        color="primary"
+                        startIcon={<Icon icon="ai" />}
+                        onClick={handleAutoRate}
+                        disabled={isRating}
+                    >
+                        Analyse
+                    </Button> */}
+
+                    <IconButton
+                        onClick={handleClose}
+                        color="primary"
+                    >
+                        <Icon icon="close" />
+                    </IconButton>
+                    
+                </DialogActions>
+                
                 <DialogTitle>
                     <CardHeader 
                         sx={{mx:-2}}
                         title={`${result.first_name} ${result.last_name}`}
                         subheader={result.title}
                         action={<>
-                            <IconButton
-                                onClick={handleHide}
-                                color="primary"
-                            >
-                                <Icon icon="delete" />
-                            </IconButton>
-                            {flagging ? (
-                                <IconButton>   
-                                    <CircularProgress size={24} color="primary" />
-                                </IconButton>   
-                            ) : (
-                                <IconButton
-                                    onClick={handleFlag}
-                                    color="primary"
-                                >
-                                    <Icon icon={!!result.flag ? "flagon" : "flagoff"} />
-                                </IconButton>
-                            )}
                             
-                            <IconButton
-                                onClick={handleClose}
-                                color="primary"
-                            >
-                                <Icon icon="close" />
-                            </IconButton>
+                            
+                            
+                            
                         </>
                         }
                         
@@ -281,18 +301,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
 
                 </DialogContent>
-                <DialogActions>
-                    <Button
-                        fullWidth
-                        variant="contained"
-                        color="primary"
-                        startIcon={<Icon icon="star" />}
-                        onClick={handleAutoRate}
-                        disabled={isRating}
-                    >
-                        Auto Analyse
-                    </Button>
-                </DialogActions>
+                
             </Dialog>
         </>
     );


### PR DESCRIPTION
UI and behavior updates across Prospects components and actions:

- Prospects.tsx: adjust HammerMenu positioning (wrapped in Box with negative right margin) and force single-column Grid items (removed sm:6) for results/table to simplify layout.
- actions/searchProspects.tsx: replace 'searching' state key with 'loading' and ensure loading is set on request start and in both success/error paths.
- components/HammerMenu.tsx: add confirmation Dialog for 'Reset all flags' and 'Unhide all hidden' actions, with dialog state, handlers, and TODO placeholder for executing actions.
- components/Result.tsx: minor spacing and typography tweaks (ButtonBase mx, caption→body2), force Dialog fullScreen, move hide/flag/close controls into DialogActions at the top, remove the bottom Auto Analyse action (left commented) and simplify CardHeader action area.

These changes improve UX (confirmation for destructive bulk actions, clearer loading state) and simplify result layout. TODO: wire up the actual reset/unhide operations invoked by the HammerMenu dialog.