### PR TITLE
Improve prospect analysis UI and add archive icon

### DIFF
--- a/app/NX/DesignSystem/components/Icon.tsx
+++ b/app/NX/DesignSystem/components/Icon.tsx
@@ -187,12 +187,17 @@ import FlagoffIcon from '@mui/icons-material/FlagOutlined';
 import ProspectsIcon from '@mui/icons-material/DataSaverOff';
 import StalkIcon from '@mui/icons-material/Camera';
 import HammerIcon from '@mui/icons-material/Build';
+import ArchiveIcon from '@mui/icons-material/Archive';
 
 export default function Icon({ icon, color }: I_Icon) {
   if (!color) color = 'inherit';
   let iconFragment = <React.Fragment />;
   switch (icon) {
-    case 'hammer':
+
+    case 'archive':
+      iconFragment = <ArchiveIcon color={color} />;
+      break;
+          case 'hammer':
       iconFragment = <HammerIcon color={color} />;
       break;
     case 'stalk':

--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -74,7 +74,7 @@ export default function Prospects() {
                     action={
                         <Button
                             startIcon={<Icon icon="reset" />}
-                            variant="contained"
+                            variant="outlined"
                             color="primary"
                             onClick={() => window.location.reload()}
                         >
@@ -92,13 +92,13 @@ export default function Prospects() {
         <>
             <Container maxWidth="lg">
                 <Box sx={{display: 'flex', mb: 2}}>
-                    <Box sx={{ mr: 1 }}>
-                        <HammerMenu />
-                    </Box>
+                    
+                    {Array.isArray(results) && !loading && <HammerMenu />}
+
                     {pagination && pagination.pages > 1 && (
                         <Pagination
                             size="small"
-                            sx={{mt:1}}
+                            sx={{mt: 0.5}}
                             count={pagination.pages}
                             page={pagination.page}
                             onChange={handlePageChange}
@@ -107,8 +107,6 @@ export default function Prospects() {
                         />
                     )}
                     <Box sx={{ flexGrow: 1 }} />
-                    
-                    
                 </Box>
                 
                 {Array.isArray(results) && results.length > 0 ? (

--- a/app/NX/Prospects/actions/analyse.tsx
+++ b/app/NX/Prospects/actions/analyse.tsx
@@ -1,7 +1,8 @@
 import type { T_UbereduxDispatch } from '../../types';
 import type { T_ApolloDoc } from '../types'
 import { setUbereduxKey } from '../../Uberedux';
-import { setProspects } from '../../Prospects';
+import { setProspects, bus } from '../../Prospects';
+import { setFeedback } from '../../DesignSystem';
 import { stalkPrompt } from '../lib/prompts';
 
 export const analyse = (
@@ -34,12 +35,17 @@ export const analyse = (
                 const current = getState().redux.prospects?.ratings || {};
                 dispatch(setProspects('ratings', { ...current, [prospect.id]: data }));
             });
+            dispatch(setFeedback({ 
+                severity: 'success', 
+                title: `Analysed ${prospect.first_name} ${prospect.last_name}`
+            }));
             dispatch((dispatch, getState) => {
                 const current = getState().redux.prospects?.isRating || {};
                 const updated = { ...current };
                 delete updated[prospect.id];
                 dispatch(setProspects('isRating', updated));
             });
+            dispatch(bus(prospect.id, true)); // Force reload of bus data to get latest analysis
 
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);

--- a/app/NX/Prospects/actions/bus.tsx
+++ b/app/NX/Prospects/actions/bus.tsx
@@ -2,15 +2,15 @@
 import type { T_UbereduxDispatch, T_RootState } from '../../types';
 import { setUbereduxKey } from '../../Uberedux';
 
-export const bus = (id: number | string): any =>
+export const bus = (id: number | string, forceReload = false): any =>
     async (dispatch: T_UbereduxDispatch, getState: () => T_RootState) => {
         try {
             const current = getState().redux.prospects.bus?.[id];
-            if (current) return; // Already loaded
+            if (current && !forceReload) return; // Already loaded and not forcing reload
 
             dispatch(setUbereduxKey({ key: `prospects.bus.${id}_loading`, value: true }));
             const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}llm/?prospect_id=${id}`;
-            console.log('endpoint', endpoint);
+            // console.log('endpoint', endpoint);
             const res = await fetch(endpoint);
             if (!res.ok) throw new Error(`Failed to fetch LLM data: ${res.status}`);
             const data = await res.json();

--- a/app/NX/Prospects/actions/initProspects.tsx
+++ b/app/NX/Prospects/actions/initProspects.tsx
@@ -26,7 +26,7 @@ export const initProspects = () =>
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
                 const base = process.env.NEXT_PUBLIC_PYTHON_URL;
-                msg = `Can't reach Python at ${base}`;
+                msg = `Can't reach Python at ${base}/health`;
             }
             dispatch(setProspects('error', msg));
             dispatch(setProspects('loading', false));

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -12,7 +12,8 @@ export const searchProspects = () => async (
         const state = getState().redux.prospects;
         const page = state?.query?.page || 1;
         const limit = state?.query?.limit || 100;
-        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}`;
+        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}&hideflagged=true`;
+        // console.log('Fetching prospects with endpoint:', endpoint);
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);
         const data = await res.json();

--- a/app/NX/Prospects/components/HammerMenu.tsx
+++ b/app/NX/Prospects/components/HammerMenu.tsx
@@ -13,6 +13,9 @@ import {
     DialogActions,
     Button,
 } from '@mui/material';
+import {
+    Build,
+} from '@mui/icons-material'
 // import { useDispatch } from '../../Uberedux';
 // import { setProspects } from '../../Prospects';
 import {Icon} from '../../DesignSystem';
@@ -57,7 +60,7 @@ export default function HammerMenu() {
                 color="primary"
                 onClick={handleClick}
             >
-                <Icon icon='hammer' />
+                <Build sx={{width: 20, height:20}} />
             </IconButton>
             <Menu
                 anchorEl={anchorEl}
@@ -68,22 +71,21 @@ export default function HammerMenu() {
             >
                 <MenuItem onClick={() => handleMenuItemClick('resetFlags')}>
                     <ListItemIcon sx={{ mr: 1 }}>
-                        <Icon color="primary" icon="flagoff" />
+                        <Icon color="primary" icon="reset" />
                     </ListItemIcon>
-                    Reset all flags
+                    Reset 
                 </MenuItem>
                 <MenuItem onClick={() => handleMenuItemClick('unhideAll')}>
                     <ListItemIcon sx={{mr:1}}>
-                        <Icon color="primary" icon="hide" />
+                        <Icon color="primary" icon="flagoff" />
                     </ListItemIcon>
-                    Unhide all hidden
+                    Show Flagged
                 </MenuItem>
             </Menu>
 
             <Dialog
                 open={dialogOpen}
-                onClose={handleDialogClose}
-            >
+                onClose={handleDialogClose}>
                 <DialogTitle>Confirm</DialogTitle>
                 <DialogContent>
                     <DialogContentText>

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -59,10 +59,12 @@ function fixPhone(phone: string) {
 }
 
 export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boolean }) {
+        
     
     const dispatch = useDispatch();
     const theme = useTheme();
     const router = useRouter();
+    const [analysisLoading, setAnalysisLoading] = React.useState(false);
     const [open, setOpen] = React.useState(false);
     const [copied, setCopied] = React.useState(false);
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -72,6 +74,32 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const isRatingMap = prospects?.isRating || {};
     const isRating = !!isRatingMap[result.id];
     const bus = useBus(result.id);
+    const busLoading = prospects?.[`bus.${result.id}_loading`];
+    let analysis = undefined;
+    try {
+        analysis = bus?.[0]?.completion ? JSON.parse(bus[0].completion) : undefined;
+    } catch (e) {
+        analysis = bus?.[0]?.completion;
+    }
+    const hasSummary = typeof analysis === 'object' && analysis !== null && 'summary' in analysis;
+    const summary = hasSummary ? analysis.summary : '';
+    const score = (typeof analysis === 'object' && analysis !== null && 'prospect_score' in analysis) ? analysis.prospect_score : 0;
+    const grade = (typeof analysis === 'object' && analysis !== null && 'prospect_grade' in analysis) ? analysis.prospect_grade : 'Z';
+
+    const recommendation = hasSummary ? analysis.recommendation : 'recommendation';
+
+    // Track previous state for summary loaded detection
+    const prevShowAnalyseRef = React.useRef(bus && !hasSummary && !analysisLoading && !busLoading);
+    // Alert when summary has loaded (transition from show-analyse to summary present)
+    React.useEffect(() => {
+        const showAnalyse = bus && !hasSummary && !analysisLoading && !busLoading;
+        if (prevShowAnalyseRef.current && !showAnalyse && hasSummary) {
+            alert('Summary has loaded!');
+        }
+        prevShowAnalyseRef.current = showAnalyse;
+    }, [bus, hasSummary, analysisLoading, busLoading]);
+
+/* {bus && !hasSummary && !analysisLoading && !busLoading ? ( */
 
     // Load LLM data when dialog opens and not already loaded
     React.useEffect(() => {
@@ -80,16 +108,27 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
         }
     }, [open, bus, dispatch, result.id]);
 
-    const handleResultClick = () => setOpen(true);
-    const handleClose = () => setOpen(false);
+    React.useEffect(() => {
+        if (analysisLoading && (hasSummary || analysis)) {
+            setAnalysisLoading(false);
+            // Force refresh the bus data for this prospect
+            dispatch(require('../../Prospects').bus(result.id));
+        }
+    }, [analysis, hasSummary, analysisLoading, dispatch, result.id]);
 
-    const handleAnalyse = () => {
-        dispatch(analyse(result as T_ApolloDoc));
-    };
+    
 
     const handleEmail = () => {
         console.log("Email clicked for", result.first_name, result.last_name);
     }
+
+    const handleResultClick = () => setOpen(true);
+    const handleClose = () => setOpen(false);
+
+    const handleAnalyse = () => {
+        setAnalysisLoading(true);
+        dispatch(analyse(result as T_ApolloDoc));
+    };
 
     const handleHide = () => {
         dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} deleted`));
@@ -98,8 +137,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
     const handleFlag = () => {
         const newFlag = !result.flag;
-        const actionText = newFlag ? 'flagged' : 'unflagged';
-        dispatch(flagProspect(result.id, newFlag, `${result.first_name} ${result.last_name} ${actionText}`));
+        dispatch(flagProspect(result.id, newFlag, `${result.first_name} ${result.last_name} updated`));
     }
 
     const handleLinkedin = () => {
@@ -110,13 +148,16 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
         dispatch(navigateTo(router, emailToTldUrl(result.email as string), '_blank'));
     };
 
-    // console.log('prospect', prospect);
     return (
         <>
-            <ButtonBase sx={{p:1, width: '100%', textAlign: 'left'}} onClick={handleResultClick}>
-                <Box sx={{ pl: 1, width: '100%', borderLeft: `2px solid ${theme.palette.primary.main}` }}>
+            <ButtonBase sx={{width: '100%', textAlign: 'left'}} onClick={handleResultClick}>
+                <Box sx={{ 
+                    pl: 1, 
+                    py: 0.25, 
+                    width: '100%', 
+                    borderLeft: `2px solid ${theme.palette.primary.main}`,
+                }}>
                     <Box sx={{display: 'flex'}}>
-
                         <Box sx={{ display: 'block', }}>
                             <Typography variant="body1">
                                 {result.first_name} {result.last_name}
@@ -136,6 +177,8 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                     </Box>
                 </Box>
             </ButtonBase>
+
+            
             <Dialog 
                 fullWidth 
                 maxWidth="sm" 
@@ -143,124 +186,162 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 onClose={handleClose} 
                 fullScreen={true}>
                 <Container maxWidth="md">
-                <DialogActions>
-                    <IconButton
-                        onClick={handleHide}
-                        color="primary"
-                    >
-                        <Icon icon="delete" />
-                    </IconButton>
-                    {flagging ? (
-                        <IconButton>
-                            <CircularProgress size={24} color="primary" />
-                        </IconButton>
-                    ) : (
+                    <DialogActions>
                         <IconButton
-                            onClick={handleFlag}
+                            onClick={handleHide}
                             color="primary"
                         >
-                            <Icon icon={!!result.flag ? "flagon" : "flagoff"} />
+                            <Icon icon="archive" />
                         </IconButton>
-                    )}
-                    <IconButton
-                        onClick={handleClose}
-                        color="primary"
-                    >
-                        <Icon icon="close" />
-                    </IconButton>
-                    
-                </DialogActions>
-                    
-                <DialogContent>
-                    <CardHeader
-                        sx={{ mx: -2 }}
-                        title={`${result.first_name} ${result.last_name}`}
-                        subheader={result.title}
-                    />
-                    <Grid container spacing={1}>
-                        <Grid size={{ xs: 12, sm: 5 }}>
-                            <Box sx={{ mb: { xs: 2, md: 0 } }}>
-                                <Typography variant="body1">
-                                    {result.company_name}
-                                </Typography>
-                                <Typography variant="body1">
-                                    {fixPhone(result.corporate_phone)}
-                                </Typography>
-                            </Box>
-                        </Grid>        
-                        <Grid size={{ xs: 12, sm: 7 }}>
-                            <List dense disablePadding>
-                                <ListItemButton onClick={handleLinkedin}>
-                                    <ListItemIcon>
-                                        <Icon icon="linkedin" color="primary" />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Profile" />
-                                </ListItemButton>
-                                <ListItemButton onClick={handleWebsite}>
-                                    <ListItemIcon>
-                                        <Icon icon="link" color="primary" />
-                                    </ListItemIcon>
-                                    <ListItemText primary={hostname} />
-                                </ListItemButton>
-                                <Tooltip
-                                    open={copied}
-                                    title="Copied!"
-                                    placement="bottom"
-                                    arrow
-                                    disableFocusListener
-                                    disableHoverListener
-                                    disableTouchListener
-                                    PopperProps={{ 
-                                        anchorEl: anchorEl ? { getBoundingClientRect: () => anchorEl.getBoundingClientRect(), 
-                                        clientWidth: anchorEl.clientWidth } : undefined
-                                    }}
-                                >
-                                    <ListItemButton onClick={e => {
-                                        navigator.clipboard.writeText(result.email);
-                                        setCopied(true);
-                                        setAnchorEl(e.currentTarget);
-                                        setTimeout(() => {
-                                            setCopied(false);
-                                            setAnchorEl(null);
-                                        }, 1500);
-                                    }}>
-                                        <ListItemIcon>
-                                            <Icon icon="email" color="primary" />
-                                        </ListItemIcon>
-                                        <ListItemText primary={result.email} />
-                                    </ListItemButton>
-                                </Tooltip>
-                            </List>
-                        </Grid>
-                    </Grid>
-
-                    <Button
+                        {flagging ? (
+                            <IconButton>
+                                <CircularProgress size={24} color="primary" />
+                            </IconButton>
+                        ) : (
+                            <IconButton
+                                onClick={handleFlag}
+                                color="primary"
+                            >
+                                <Icon icon="save" />
+                            </IconButton>
+                        )}
+                        <IconButton
+                            onClick={handleClose}
+                            color="primary"
+                        >
+                            <Icon icon="close" />
+                        </IconButton>
                         
-                        variant="contained"
-                        color="primary"
-                        onClick={handleAnalyse}
-                        startIcon={<Icon icon="ai" />}
-                        sx={{my:3}}
-                    >
+                    </DialogActions>
+                        
+                    <DialogContent>
 
-                        Analyse ?
+                        <CardHeader
+                            sx={{ mx: -2 }}
+                            title={`${result.first_name} ${result.last_name}`}
+                            subheader={result.title}
+                        />
 
-                    </Button>
+                        <Typography variant="body1">
+                            {result.company_name}
+                        </Typography>
+                        <Typography variant="body1">
+                            {fixPhone(result.corporate_phone)}
+                        </Typography>
+                        
 
-                        <pre>fetch /llm/{result.id}: {JSON.stringify(bus, null, 2)}</pre>
 
-                    {isRating && (
-                        <Box sx={{ my: 2 }}>
-                            <Typography variant="body2" sx={{ my: 2, }} color="primary">
-                                Analysing this prospect with Gemini... Please wait for a commercial summary and score.
-                            </Typography>
-                            <Box sx={{ width: '100%' }}>
-                                <LinearProgress color="primary" />
+                        <Grid container spacing={1}>
+                            <Grid size={{ xs: 12, sm: 5 }}>
+                                <Box sx={{ mb: { xs: 2, md: 0 } }}>
+                                    
+                                    
+                                </Box>
+                            </Grid>        
+                            <Grid size={{ xs: 12, sm: 7 }}>
+                                <List dense disablePadding>
+                                    <ListItemButton onClick={handleLinkedin}>
+                                        <ListItemIcon>
+                                            <Icon icon="linkedin" color="primary" />
+                                        </ListItemIcon>
+                                        <ListItemText primary="Profile" />
+                                    </ListItemButton>
+                                    <ListItemButton onClick={handleWebsite}>
+                                        <ListItemIcon>
+                                            <Icon icon="link" color="primary" />
+                                        </ListItemIcon>
+                                        <ListItemText primary={hostname} />
+                                    </ListItemButton>
+                                    <Tooltip
+                                        open={copied}
+                                        title="Copied!"
+                                        placement="bottom"
+                                        arrow
+                                        disableFocusListener
+                                        disableHoverListener
+                                        disableTouchListener
+                                        PopperProps={{ 
+                                            anchorEl: anchorEl ? { getBoundingClientRect: () => anchorEl.getBoundingClientRect(), 
+                                            clientWidth: anchorEl.clientWidth } : undefined
+                                        }}
+                                    >
+                                        <ListItemButton onClick={e => {
+                                            navigator.clipboard.writeText(result.email);
+                                            setCopied(true);
+                                            setAnchorEl(e.currentTarget);
+                                            setTimeout(() => {
+                                                setCopied(false);
+                                                setAnchorEl(null);
+                                            }, 1500);
+                                        }}>
+                                            <ListItemIcon>
+                                                <Icon icon="email" color="primary" />
+                                            </ListItemIcon>
+                                            <ListItemText primary={result.email} />
+                                        </ListItemButton>
+                                    </Tooltip>
+                                </List>
+                            </Grid>
+                        </Grid>
+
+
+                        {hasSummary && (
+                            <>
+                                <Box sx={{ mt: 2, display: 'flex', alignItems: 'center' }}>
+                                    <Box sx={{ minWidth: 75 }}>
+                                        <Typography variant="h3">
+                                            {`${Math.round(score)}%`}
+                                        </Typography>
+                                    </Box>
+                                    <Box sx={{ width: '100%' }}>
+                                        <LinearProgress
+                                            variant="determinate"
+                                            value={score}
+                                            color="primary"
+
+                                        />
+                                    </Box>
+                                </Box>
+                            </>
+                        )}
+
+                        {hasSummary && (
+                            <Box sx={{ my: 0 }}>
+                                
+                                <Typography variant="body1" sx={{ my: 2 }}>
+                                    {summary}
+                                </Typography>
+                                <Typography variant="body1" sx={{ my: 2 }}>
+                                    {recommendation}
+                                </Typography>
+
                             </Box>
-                        </Box>
-                    )}
-                    
-                </DialogContent>
+                        )}
+
+
+                        {/* Only show Analyse button if there is no summary and not loading. Show loading text if loading and button is hidden. */}
+                        {bus && !hasSummary && !analysisLoading && !busLoading ? (
+                            <Button
+                                variant="outlined"
+                                color="primary"
+                                onClick={handleAnalyse}
+                                startIcon={<Icon icon="google" />}
+                                sx={{my:3}}
+                            >
+                                Analyse
+                            </Button>
+                        ) : null}
+            
+                        {isRating && (
+                            <Box sx={{ my: 2, width: '100%' }}>
+                                <LinearProgress color="primary" />
+                                <Typography variant="body2" sx={{ my: 2, }} color="primary">
+                                    Analysing prospect with Gemini...
+                                </Typography>
+                            </Box>
+                        )}
+                        
+                    </DialogContent>
                 </Container>
             </Dialog>
         </>

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -292,6 +292,7 @@ export type I_Icon = {
     | 'more'
     | 'heart'
     | 'hammer'
+    | 'archive'
     | 'maths'
     | 'free'
     | 'seniority'

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -6,10 +6,11 @@ description: Modern, full-stack web app framework
 tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 ---
 
+[PageLink icon="prospects" title="Prospects°" url="/prospects"]  
 [PageLink icon="mobile" title="Tenants°" url="/tenants"]  
 [PageLink icon="features" title="Features" url="/features"]  
 [PageLink icon="techstack" title="Techstack" url="/techstack"]  
 [PageLink icon="github" title="Open Source" url="/techstack/git"]  
-[PageLink icon="prospects" title="Prospects°" url="/prospects"]  
+
 
 NX is a modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.


### PR DESCRIPTION
Add an 'archive' icon type and update types. Revamp Prospect UI and Result dialog to better handle LLM analysis: add analysisLoading state, parse bus LLM results (summary, score, grade, recommendation), show progress/summary/recommendation, and only show Analyse button when appropriate. Dispatch feedback on analysis and force bus reload after analysis. Make bus action accept forceReload to allow refetching; silence a console.log. Default search to hide flagged prospects (hideflagged=true). Minor UX tweaks: change reset button to outlined, adjust pagination spacing, conditionally render HammerMenu, update HammerMenu icons/labels, and tweak initProspects error message to include /health. Update public markdown links ordering. Overall goal: smoother analysis flow, clearer UI, and ability to refresh LLM data.