### PR TITLE
Improve Prospects UI and hide-flagged fetch

### DIFF
--- a/app/NX/DesignSystem/components/Icon.tsx
+++ b/app/NX/DesignSystem/components/Icon.tsx
@@ -187,7 +187,7 @@ import FlagoffIcon from '@mui/icons-material/FlagOutlined';
 import ProspectsIcon from '@mui/icons-material/DataSaverOff';
 import StalkIcon from '@mui/icons-material/Camera';
 import HammerIcon from '@mui/icons-material/Build';
-import ArchiveIcon from '@mui/icons-material/Archive';
+import ArchiveIcon from '@mui/icons-material/ArchiveOutlined';
 
 export default function Icon({ icon, color }: I_Icon) {
   if (!color) color = 'inherit';

--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -8,6 +8,7 @@ import {
     Alert,
     Grid,
     Pagination,
+    Typography,
 } from '@mui/material';
 import {
     useDispatch,
@@ -92,21 +93,28 @@ export default function Prospects() {
         <>
             <Container maxWidth="lg">
                 <Box sx={{display: 'flex', mb: 2}}>
+
+                    <Typography variant="h4" color="textSecondary" sx={{ mr: 1 }}>
+                        {pagination ? ` ${pagination.total || 0}` : null}
+                    </Typography>
                     
                     {Array.isArray(results) && !loading && <HammerMenu />}
 
+                    <Box sx={{ flexGrow: 1 }} />
                     {pagination && pagination.pages > 1 && (
                         <Pagination
                             size="small"
-                            sx={{mt: 0.5}}
+                            sx={{ mt: 0.5 }}
                             count={pagination.pages}
                             page={pagination.page}
                             onChange={handlePageChange}
                             color="standard"
                             shape="rounded"
+                            siblingCount={0}
+                            boundaryCount={1}
                         />
                     )}
-                    <Box sx={{ flexGrow: 1 }} />
+                    
                 </Box>
                 
                 {Array.isArray(results) && results.length > 0 ? (

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -9,10 +9,11 @@ export const searchProspects = () => async (
 ) => {
     try {
         dispatch(setProspects('loading', true));
+        const hideFlagged = true; // Set to true to hide flagged prospects
         const state = getState().redux.prospects;
         const page = state?.query?.page || 1;
         const limit = state?.query?.limit || 100;
-        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}&hideflagged=true`;
+        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}prospects?page=${page}&limit=${limit}&hideflagged=${hideFlagged}`;
         // console.log('Fetching prospects with endpoint:', endpoint);
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -7,7 +7,6 @@ import {
     IconButton,
     Tooltip,
     useTheme,
-    CircularProgress,
     ButtonBase,
     Typography,
     Box,
@@ -20,7 +19,6 @@ import {
     ListItemText,
     ListItemIcon,
     LinearProgress,
-    Grid,
 } from '@mui/material';
 import {useRouter} from 'next/navigation';
 import {
@@ -137,7 +135,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
     const handleFlag = () => {
         const newFlag = !result.flag;
-        dispatch(flagProspect(result.id, newFlag, `${result.first_name} ${result.last_name} updated`));
+        dispatch(flagProspect(result.id, newFlag, `${result.first_name} ${result.last_name} saved`));
     }
 
     const handleLinkedin = () => {
@@ -158,6 +156,11 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                     borderLeft: `2px solid ${theme.palette.primary.main}`,
                 }}>
                     <Box sx={{display: 'flex'}}>
+                        {(!!result.flag) && (
+                            <Box sx={{ mr: 1, mt: 0.5 }}>
+                                <Icon icon="ai" color="primary" />
+                            </Box>
+                        )}
                         <Box sx={{ display: 'block', }}>
                             <Typography variant="body1">
                                 {result.first_name} {result.last_name}
@@ -169,11 +172,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                             </Typography>
                         </Box>
 
-                        {(!!result.flag) && (
-                            <Box sx={{ ml: 1, mt: 2 }}>
-                                <Icon icon="flagon" color="primary" />
-                            </Box>
-                        )}
+                        
                     </Box>
                 </Box>
             </ButtonBase>
@@ -187,24 +186,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 fullScreen={true}>
                 <Container maxWidth="md">
                     <DialogActions>
-                        <IconButton
-                            onClick={handleHide}
-                            color="primary"
-                        >
-                            <Icon icon="archive" />
-                        </IconButton>
-                        {flagging ? (
-                            <IconButton>
-                                <CircularProgress size={24} color="primary" />
-                            </IconButton>
-                        ) : (
-                            <IconButton
-                                onClick={handleFlag}
-                                color="primary"
-                            >
-                                <Icon icon="save" />
-                            </IconButton>
-                        )}
+                        
                         <IconButton
                             onClick={handleClose}
                             color="primary"
@@ -228,18 +210,10 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                         <Typography variant="body1">
                             {fixPhone(result.corporate_phone)}
                         </Typography>
-                        
 
-
-                        <Grid container spacing={1}>
-                            <Grid size={{ xs: 12, sm: 5 }}>
-                                <Box sx={{ mb: { xs: 2, md: 0 } }}>
-                                    
-                                    
-                                </Box>
-                            </Grid>        
-                            <Grid size={{ xs: 12, sm: 7 }}>
-                                <List dense disablePadding>
+                                <List sx={{
+                                    mt: 2,
+                                }} dense disablePadding>
                                     <ListItemButton onClick={handleLinkedin}>
                                         <ListItemIcon>
                                             <Icon icon="linkedin" color="primary" />
@@ -281,9 +255,6 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                                         </ListItemButton>
                                     </Tooltip>
                                 </List>
-                            </Grid>
-                        </Grid>
-
 
                         {hasSummary && (
                             <>
@@ -301,6 +272,27 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
                                         />
                                     </Box>
+                                </Box>
+                                <Box sx={{display: 'flex', gap: 2}}>
+                                    <Button
+                                        fullWidth
+                                        variant="outlined"
+                                        startIcon={<Icon icon="delete" />}
+                                        onClick={handleHide}
+                                        color="primary"
+                                        sx={{ mt: 2 }}>
+                                        Discard
+                                    </Button>
+                                    <Button 
+                                        fullWidth
+                                        variant="contained" 
+                                        startIcon={<Icon icon="save" />}
+                                        onClick={handleFlag}
+                                        color="primary" 
+                                        sx={{ mt: 2 }}>
+                                        Save
+                                    </Button>
+                                        
                                 </Box>
                             </>
                         )}
@@ -321,19 +313,27 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
                         {/* Only show Analyse button if there is no summary and not loading. Show loading text if loading and button is hidden. */}
                         {bus && !hasSummary && !analysisLoading && !busLoading ? (
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                onClick={handleAnalyse}
-                                startIcon={<Icon icon="google" />}
-                                sx={{my:3}}
-                            >
-                                Analyse
-                            </Button>
+                            <Box sx={{ display: 'flex', gap: 2, mt: 5 }}>
+                                <Button
+                                    variant="outlined"
+                                    startIcon={<Icon icon="delete" />}
+                                    onClick={handleHide}
+                                    color="primary">
+                                    Discard
+                                </Button>
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={handleAnalyse}
+                                    startIcon={<Icon icon="google" />}
+                                >
+                                    Analyse
+                                </Button>
+                            </Box>
                         ) : null}
             
                         {isRating && (
-                            <Box sx={{ my: 2, width: '100%' }}>
+                            <Box sx={{ mt: 4, width: '100%' }}>
                                 <LinearProgress color="primary" />
                                 <Typography variant="body2" sx={{ my: 2, }} color="primary">
                                     Analysing prospect with Gemini...


### PR DESCRIPTION
Refactor Prospect list and result UI and make hide-flagged configurable.

- Use ArchiveOutlined icon import for consistency.
- Show total results count in the header and adjust header layout (flex spacing, Pagination styling, sibling/boundary counts).
- Introduce hideFlagged variable and use it when building the prospects fetch endpoint instead of hardcoding the query.
- Major Result dialog/UI changes: update flag dispatch message, show flag indicator, remove unused spinner/archive/old flag buttons, restructure list layout, add Discard and Save buttons, relocate and restyle Analyse button, and adjust progress spacing.

These changes tidy up the UI, improve pagination display, and make the hide-flagged behavior easier to control.