### PR TITLE
Add sendAnalysis action and email UI

### DIFF
--- a/app/NX/Prospects/actions/sendAnalysis.tsx
+++ b/app/NX/Prospects/actions/sendAnalysis.tsx
@@ -1,0 +1,124 @@
+import type { T_UbereduxDispatch } from '../../types';
+import type { T_ApolloDoc } from '../types'
+import { setUbereduxKey } from '../../Uberedux';
+import { setProspects, bus } from '../../Prospects';
+import { setFeedback } from '../../DesignSystem';
+
+export const sendAnalysis = (
+        prospect: T_ApolloDoc,
+        analysis: any,
+        to: string
+) => async (dispatch: T_UbereduxDispatch) => {
+        try {
+                const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}resend`;
+                dispatch((dispatch, getState) => {
+                        const current = getState().redux.prospects?.isSending || {};
+                        dispatch(setProspects('isSending', { ...current, [prospect.id]: true }));
+                });
+
+                const subject = `Analysis for ${prospect.first_name} ${prospect.last_name}`;
+                // Transform analysis object into a beautiful, Gmail-friendly HTML email
+                const html = `
+<div style=\"font-family: 'Segoe UI', Arial, sans-serif; background: #fafbfc; padding: 32px; color: #222;\">
+    <table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" style=\"max-width: 600px; margin: auto; background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); border: 1px solid #eee;\">
+        <tr>
+            <td style=\"padding: 32px 32px 16px 32px;\">
+                <h2 style=\"margin: 0 0 8px 0; color: #2d3748; font-size: 24px;\">Prospect Analysis</h2>
+                <div style=\"color: #555; font-size: 16px; margin-bottom: 16px;\">
+                    <strong>${prospect.first_name} ${prospect.last_name}</strong><br/>
+                    ${prospect.title ? prospect.title + ' at ' : ''}${prospect.company_name || ''}
+                </div>
+                <div style=\"font-size: 13px; color: #333; margin-bottom: 24px;\">
+                    ${analysis.summary}
+                </div>
+                <table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" style=\"margin-bottom: 24px;\">
+                    <tr>
+                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Role Inference:</strong></td>
+                        <td style=\"padding: 0 0 8px 0; color: #444;\">${analysis.role_inference}</td>
+                    </tr>
+                    <tr>
+                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Seniority Level:</strong></td>
+                        <td style=\"padding: 0 0 8px 0; color: #444; text-transform: capitalize;\">${analysis.seniority_level}</td>
+                    </tr>
+                    <tr>
+                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Decision Power:</strong></td>
+                        <td style=\"padding: 0 0 8px 0; color: #444; text-transform: capitalize;\">${analysis.decision_power}</td>
+                    </tr>
+                    <tr>
+                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Prospect Score:</strong></td>
+                        <td style=\"padding: 0 0 8px 0; color: #444;\">${analysis.prospect_score} / 100 (Grade: <strong>${analysis.prospect_grade}</strong>)</td>
+                    </tr>
+                </table>
+
+                <div style=\"margin-bottom: 18px;\">
+                    <strong>Key Priorities:</strong>
+                    <ul style=\"margin: 8px 0 0 18px; color: #444;\">
+                        ${(analysis.key_priorities || []).map((item: string) => `<li>${item}</li>`).join('')}
+                    </ul>
+                </div>
+                <div style=\"margin-bottom: 18px;\">
+                    <strong>Likely Pain Points:</strong>
+                    <ul style=\"margin: 8px 0 0 18px; color: #444;\">
+                        ${(analysis.likely_pain_points || []).map((item: string) => `<li>${item}</li>`).join('')}
+                    </ul>
+                </div>
+                <div style=\"margin-bottom: 18px;\">
+                    <strong>Intent Alignment:</strong>
+                    <div style=\"margin-top: 6px; color: #444;\">${analysis.intent_alignment}</div>
+                </div>
+                <div style=\"margin-bottom: 18px;\">
+                    <strong>Recommendation:</strong>
+                    <div style=\"margin-top: 6px; color: #444;\">${analysis.recommendation}</div>
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td style=\"padding: 0 32px 24px 32px; color: #aaa; font-size: 13px;\">
+                <hr style=\"border: none; border-top: 1px solid #eee; margin: 24px 0 16px 0;\" />
+                <div>Email generated automatically by your Prospects platform.</div>
+            </td>
+        </tr>
+    </table>
+</div>
+`;
+        const payload = { to, subject, html };
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        await response.json();
+
+        dispatch(setFeedback({
+            severity: 'success',
+            title: `Analysis sent to ${to}`,
+        }));
+
+        dispatch((dispatch, getState) => {
+            const current = getState().redux.prospects?.isRating || {};
+            const updated = { ...current };
+            delete updated[prospect.id];
+            dispatch(setProspects('isRating', updated));
+        });
+        dispatch(bus(prospect.id, true));
+    } catch (e) {
+        let msg = e instanceof Error ? e.message : String(e);
+        if (msg === 'Failed to fetch') {
+            const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}resend`;
+            msg = `Can't fetch endpoint ${endpoint}`;
+        }
+        dispatch((dispatch, getState) => {
+            const current = getState().redux.prospects?.isRating || {};
+            const updated = { ...current };
+            delete updated[prospect.id];
+            dispatch(setProspects('isRating', updated));
+        });
+        dispatch(setProspects('error', msg));
+        dispatch(setUbereduxKey({ key: 'error', value: msg }));
+    }
+};

--- a/app/NX/Prospects/components/Email.tsx
+++ b/app/NX/Prospects/components/Email.tsx
@@ -1,0 +1,29 @@
+'use client';
+import * as React from 'react';
+import {
+    Box,
+    Button,
+    Typography,
+} from '@mui/material';
+import {
+    useDispatch,
+} from '../../Uberedux';
+import {
+    Icon,
+} from '../../DesignSystem';
+import {
+    useProspects,
+} from '../../Prospects';
+
+export default function Email() {
+
+    const state = useProspects();
+    const loading = state?.loading;
+
+    return (
+        <>
+
+            
+        </>
+    );
+}

--- a/app/NX/Prospects/components/HammerMenu.tsx
+++ b/app/NX/Prospects/components/HammerMenu.tsx
@@ -77,9 +77,9 @@ export default function HammerMenu() {
                 </MenuItem>
                 <MenuItem onClick={() => handleMenuItemClick('unhideAll')}>
                     <ListItemIcon sx={{mr:1}}>
-                        <Icon color="primary" icon="flagoff" />
+                        <Icon color="primary" icon="archive" />
                     </ListItemIcon>
-                    Show Flagged
+                    Show Saved
                 </MenuItem>
             </Menu>
 

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -32,9 +32,10 @@ import {
     hideProspect,
     flagProspect,
     useProspects,
+    sendAnalysis,
     analyse,
     useBus,
-} from '../../Prospects'
+} from '../../Prospects';
 
 function emailToTldUrl(email: string): string {
     if (typeof email !== 'string') return '';
@@ -56,9 +57,7 @@ function fixPhone(phone: string) {
         : phone;
 }
 
-export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boolean }) {
-        
-    
+export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boolean }) {    
     const dispatch = useDispatch();
     const theme = useTheme();
     const router = useRouter();
@@ -68,7 +67,6 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const hostname = emailToHostname(result.email as string);
     const prospects = useProspects();
-    const flagging = prospects?.flagging;
     const isRatingMap = prospects?.isRating || {};
     const isRating = !!isRatingMap[result.id];
     const bus = useBus(result.id);
@@ -82,7 +80,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     const hasSummary = typeof analysis === 'object' && analysis !== null && 'summary' in analysis;
     const summary = hasSummary ? analysis.summary : '';
     const score = (typeof analysis === 'object' && analysis !== null && 'prospect_score' in analysis) ? analysis.prospect_score : 0;
-    const grade = (typeof analysis === 'object' && analysis !== null && 'prospect_grade' in analysis) ? analysis.prospect_grade : 'Z';
+    // const grade = (typeof analysis === 'object' && analysis !== null && 'prospect_grade' in analysis) ? analysis.prospect_grade : 'Z';
 
     const recommendation = hasSummary ? analysis.recommendation : 'recommendation';
 
@@ -116,9 +114,27 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
 
     
 
-    const handleEmail = () => {
-        console.log("Email clicked for", result.first_name, result.last_name);
-    }
+    // Email dialog state
+    const [emailDialogOpen, setEmailDialogOpen] = React.useState(false);
+    const [emailInput, setEmailInput] = React.useState(result.email || '');
+    const [emailValid, setEmailValid] = React.useState(false);
+
+    // Email validation regex
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    React.useEffect(() => {
+        setEmailValid(emailRegex.test(emailInput));
+    }, [emailInput]);
+
+    const handleOpenEmailDialog = () => {
+        setEmailInput('goldlabel.apps@gmail.com');
+        setEmailDialogOpen(true);
+    };
+    const handleCloseEmailDialog = () => setEmailDialogOpen(false);
+    const handleSendEmail = () => {
+        if (!emailValid) return;
+        setEmailDialogOpen(false);
+        dispatch(sendAnalysis({ ...result }, analysis, emailInput));
+    };
 
     const handleResultClick = () => setOpen(true);
     const handleClose = () => setOpen(false);
@@ -129,7 +145,7 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
     };
 
     const handleHide = () => {
-        dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} deleted`));
+        dispatch(hideProspect(result.id, !result.hide, `${result.first_name} ${result.last_name} discarded`));
         handleClose();
     }
 
@@ -171,8 +187,6 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                                 {result.title} at {result.company_name} 
                             </Typography>
                         </Box>
-
-                        
                     </Box>
                 </Box>
             </ButtonBase>
@@ -186,14 +200,12 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                 fullScreen={true}>
                 <Container maxWidth="md">
                     <DialogActions>
-                        
                         <IconButton
                             onClick={handleClose}
                             color="primary"
                         >
                             <Icon icon="close" />
                         </IconButton>
-                        
                     </DialogActions>
                         
                     <DialogContent>
@@ -205,60 +217,57 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                         />
 
                         <Typography variant="body1">
-                            {result.company_name}
-                        </Typography>
-                        <Typography variant="body1">
-                            {fixPhone(result.corporate_phone)}
+                            {result.company_name} | {fixPhone(result.corporate_phone)}
                         </Typography>
 
-                                <List sx={{
-                                    mt: 2,
-                                }} dense disablePadding>
-                                    <ListItemButton onClick={handleLinkedin}>
-                                        <ListItemIcon>
-                                            <Icon icon="linkedin" color="primary" />
-                                        </ListItemIcon>
-                                        <ListItemText primary="Profile" />
-                                    </ListItemButton>
-                                    <ListItemButton onClick={handleWebsite}>
-                                        <ListItemIcon>
-                                            <Icon icon="link" color="primary" />
-                                        </ListItemIcon>
-                                        <ListItemText primary={hostname} />
-                                    </ListItemButton>
-                                    <Tooltip
-                                        open={copied}
-                                        title="Copied!"
-                                        placement="bottom"
-                                        arrow
-                                        disableFocusListener
-                                        disableHoverListener
-                                        disableTouchListener
-                                        PopperProps={{ 
-                                            anchorEl: anchorEl ? { getBoundingClientRect: () => anchorEl.getBoundingClientRect(), 
-                                            clientWidth: anchorEl.clientWidth } : undefined
-                                        }}
-                                    >
-                                        <ListItemButton onClick={e => {
-                                            navigator.clipboard.writeText(result.email);
-                                            setCopied(true);
-                                            setAnchorEl(e.currentTarget);
-                                            setTimeout(() => {
-                                                setCopied(false);
-                                                setAnchorEl(null);
-                                            }, 1500);
-                                        }}>
-                                            <ListItemIcon>
-                                                <Icon icon="email" color="primary" />
-                                            </ListItemIcon>
-                                            <ListItemText primary={result.email} />
-                                        </ListItemButton>
-                                    </Tooltip>
-                                </List>
+                        <List sx={{
+                            mt: 2,
+                        }} dense disablePadding>
+                            <ListItemButton onClick={handleLinkedin}>
+                                <ListItemIcon>
+                                    <Icon icon="linkedin" color="primary" />
+                                </ListItemIcon>
+                                <ListItemText primary="Profile" />
+                            </ListItemButton>
+                            <ListItemButton onClick={handleWebsite}>
+                                <ListItemIcon>
+                                    <Icon icon="link" color="primary" />
+                                </ListItemIcon>
+                                <ListItemText primary={hostname} />
+                            </ListItemButton>
+                            <Tooltip
+                                open={copied}
+                                title="Copied!"
+                                placement="bottom"
+                                arrow
+                                disableFocusListener
+                                disableHoverListener
+                                disableTouchListener
+                                PopperProps={{ 
+                                    anchorEl: anchorEl ? { getBoundingClientRect: () => anchorEl.getBoundingClientRect(), 
+                                    clientWidth: anchorEl.clientWidth } : undefined
+                                }}
+                            >
+                                <ListItemButton onClick={e => {
+                                    navigator.clipboard.writeText(result.email);
+                                    setCopied(true);
+                                    setAnchorEl(e.currentTarget);
+                                    setTimeout(() => {
+                                        setCopied(false);
+                                        setAnchorEl(null);
+                                    }, 1500);
+                                }}>
+                                    <ListItemIcon>
+                                        <Icon icon="email" color="primary" />
+                                    </ListItemIcon>
+                                    <ListItemText primary={result.email} />
+                                </ListItemButton>
+                            </Tooltip>
+                        </List>
 
                         {hasSummary && (
                             <>
-                                <Box sx={{ mt: 2, display: 'flex', alignItems: 'center' }}>
+                                <Box sx={{ mt: 4, mb: 1, display: 'flex', alignItems: 'center' }}>
                                     <Box sx={{ minWidth: 75 }}>
                                         <Typography variant="h3">
                                             {`${Math.round(score)}%`}
@@ -269,31 +278,81 @@ export default function Result({ result, autoOpen }: I_Result & { autoOpen?: boo
                                             variant="determinate"
                                             value={score}
                                             color="primary"
-
                                         />
                                     </Box>
                                 </Box>
                                 <Box sx={{display: 'flex', gap: 2}}>
                                     <Button
                                         fullWidth
-                                        variant="outlined"
+                                        variant="text"
                                         startIcon={<Icon icon="delete" />}
                                         onClick={handleHide}
                                         color="primary"
-                                        sx={{ mt: 2 }}>
+                                     >
                                         Discard
                                     </Button>
                                     <Button 
                                         fullWidth
-                                        variant="contained" 
-                                        startIcon={<Icon icon="save" />}
+                                        variant="outlined" 
+                                        startIcon={<Icon icon="archive" />}
                                         onClick={handleFlag}
                                         color="primary" 
-                                        sx={{ mt: 2 }}>
-                                        Save
+                                    >
+                                        Keep
                                     </Button>
+
+                                    <Button
+                                        fullWidth
+                                        variant="contained"
+                                        startIcon={<Icon icon="email" />}
+                                        onClick={handleOpenEmailDialog}
+                                    >
+                                        Send
+                                    </Button>
+                                                    {/* Email Input Dialog */}
+                                                    <Dialog open={emailDialogOpen} onClose={handleCloseEmailDialog} maxWidth="xs" fullWidth>
+                                                        <DialogContent>
+                                                            <Typography variant="h6" sx={{ mb: 2 }}>
+                                                                Send to
+                                                            </Typography>
+                                                            <input
+                                                                type="email"
+                                                                value={emailInput}
+                                                                onChange={e => setEmailInput(e.target.value)}
+                                                                placeholder="Enter recipient email"
+                                                                style={{
+                                                                    width: '100%',
+                                                                    padding: '12px',
+                                                                    fontSize: '16px',
+                                                                    border: emailValid ? '1px solid #ccc' : '1.5px solid #e57373',
+                                                                    borderRadius: '6px',
+                                                                    outline: 'none',
+                                                                    marginBottom: '12px',
+                                                                }}
+                                                                autoFocus
+                                                            />
+                                                            {!emailValid && emailInput && (
+                                                                <Typography color="error" variant="body2" sx={{ mb: 1 }}>
+                                                                    Please enter a valid email address.
+                                                                </Typography>
+                                                            )}
+                                                        </DialogContent>
+                                                        <DialogActions>
+                                                            <Button onClick={handleCloseEmailDialog} color="secondary">Cancel</Button>
+                                                            <Button
+                                                                onClick={handleSendEmail}
+                                                                color="primary"
+                                                                variant="contained"
+                                                                disabled={!emailValid}
+                                                                endIcon={<Icon icon="send" />}
+                                                            >
+                                                                Send
+                                                            </Button>
+                                                        </DialogActions>
+                                                    </Dialog>
                                         
                                 </Box>
+                               
                             </>
                         )}
 

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -1,12 +1,14 @@
 import Prospects from './Prospects';
 import Search from './components/Search';
 import HammerMenu from './components/HammerMenu';
+import Email from './components/Email';
 import Result from './components/Result';
 import { initProspects } from './actions/initProspects';
 import { updateQuery } from './actions/updateQuery';
 import { searchProspects } from './actions/searchProspects';
 import { resetQuery } from './actions/resetQuery';
 import { setProspects } from './actions/setProspects';
+import { sendAnalysis } from './actions/sendAnalysis';
 import { useProspects } from './hooks/useProspects';
 import { promptMagentoPlugin, stalkPrompt } from './lib/prompts';
 import { normaliseForChipSelect } from './lib/normalise';
@@ -21,11 +23,13 @@ export {
     initProspects,
     searchProspects,
     setProspects,
+    sendAnalysis,
     useProspects,
     useBus,
     Search,
     Result,
     HammerMenu,
+    Email,
     updateQuery,
     resetQuery,
     normaliseForChipSelect,

--- a/app/NX/Prospects/lib/makeHTML.tsx
+++ b/app/NX/Prospects/lib/makeHTML.tsx
@@ -1,0 +1,7 @@
+// export function normaliseForChipSelect<T>(data: T[], labelKey: keyof T, valueKey: keyof T): { label: string; value: string }[] {
+//     return data.map(item => ({
+//         label: String(item[labelKey]),
+//         value: String(item[valueKey]),
+//     }));
+// }
+


### PR DESCRIPTION
Add sendAnalysis action to Prospects to POST an HTML analysis payload to the Python resend endpoint with success/error handling and state updates (isSending/isRating, feedback, bus). Add a new Email component (placeholder) and a makeHTML stub. Update Result component to include an email dialog (validation, send button), wire sendAnalysis dispatch, adjust UI (combine company/phone, adjust spacing), change discard/save labels/icons, and minor cleanup (remove unused flagging, comment out grade). Update HammerMenu to use archive icon/label and export new Email/sendAnalysis from index.