### PR TITLE
Revamp prospect analysis email template

### DIFF
--- a/app/NX/Prospects/actions/sendAnalysis.tsx
+++ b/app/NX/Prospects/actions/sendAnalysis.tsx
@@ -16,69 +16,59 @@ export const sendAnalysis = (
                         dispatch(setProspects('isSending', { ...current, [prospect.id]: true }));
                 });
 
-                const subject = `Analysis for ${prospect.first_name} ${prospect.last_name}`;
+                const subject = `Analysis of ${prospect.first_name} ${prospect.last_name}`;
                 // Transform analysis object into a beautiful, Gmail-friendly HTML email
                 const html = `
-<div style=\"font-family: 'Segoe UI', Arial, sans-serif; background: #fafbfc; padding: 32px; color: #222;\">
-    <table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" style=\"max-width: 600px; margin: auto; background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); border: 1px solid #eee;\">
-        <tr>
-            <td style=\"padding: 32px 32px 16px 32px;\">
-                <h2 style=\"margin: 0 0 8px 0; color: #2d3748; font-size: 24px;\">Prospect Analysis</h2>
-                <div style=\"color: #555; font-size: 16px; margin-bottom: 16px;\">
-                    <strong>${prospect.first_name} ${prospect.last_name}</strong><br/>
-                    ${prospect.title ? prospect.title + ' at ' : ''}${prospect.company_name || ''}
-                </div>
-                <div style=\"font-size: 13px; color: #333; margin-bottom: 24px;\">
-                    ${analysis.summary}
-                </div>
-                <table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" style=\"margin-bottom: 24px;\">
-                    <tr>
-                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Role Inference:</strong></td>
-                        <td style=\"padding: 0 0 8px 0; color: #444;\">${analysis.role_inference}</td>
-                    </tr>
-                    <tr>
-                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Seniority Level:</strong></td>
-                        <td style=\"padding: 0 0 8px 0; color: #444; text-transform: capitalize;\">${analysis.seniority_level}</td>
-                    </tr>
-                    <tr>
-                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Decision Power:</strong></td>
-                        <td style=\"padding: 0 0 8px 0; color: #444; text-transform: capitalize;\">${analysis.decision_power}</td>
-                    </tr>
-                    <tr>
-                        <td style=\"padding: 0 0 8px 0; font-size: 13px;\"><strong>Prospect Score:</strong></td>
-                        <td style=\"padding: 0 0 8px 0; color: #444;\">${analysis.prospect_score} / 100 (Grade: <strong>${analysis.prospect_grade}</strong>)</td>
-                    </tr>
-                </table>
+<div style=\"font-family: 'Segoe UI', Arial, sans-serif; background: #fafbfc; padding: 32px; color: #222; max-width: 600px; margin: auto; background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); border: 1px solid #eee;\">
+    <h2 style=\"margin: 0 0 8px 0; color: #364450; font-size: 24px;\">Prospects°</h2>
+    <div style=\"color: #555; font-size: 16px; margin-bottom: 16px;\">
+        <strong>${prospect.first_name} ${prospect.last_name}</strong><br/>
+        ${prospect.title ? prospect.title + ' at ' : ''}${prospect.company_name || ''}
+    </div>
 
-                <div style=\"margin-bottom: 18px;\">
-                    <strong>Key Priorities:</strong>
-                    <ul style=\"margin: 8px 0 0 18px; color: #444;\">
-                        ${(analysis.key_priorities || []).map((item: string) => `<li>${item}</li>`).join('')}
-                    </ul>
-                </div>
-                <div style=\"margin-bottom: 18px;\">
-                    <strong>Likely Pain Points:</strong>
-                    <ul style=\"margin: 8px 0 0 18px; color: #444;\">
-                        ${(analysis.likely_pain_points || []).map((item: string) => `<li>${item}</li>`).join('')}
-                    </ul>
-                </div>
-                <div style=\"margin-bottom: 18px;\">
-                    <strong>Intent Alignment:</strong>
-                    <div style=\"margin-top: 6px; color: #444;\">${analysis.intent_alignment}</div>
-                </div>
-                <div style=\"margin-bottom: 18px;\">
-                    <strong>Recommendation:</strong>
-                    <div style=\"margin-top: 6px; color: #444;\">${analysis.recommendation}</div>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td style=\"padding: 0 32px 24px 32px; color: #aaa; font-size: 13px;\">
-                <hr style=\"border: none; border-top: 1px solid #eee; margin: 24px 0 16px 0;\" />
-                <div>Email generated automatically by your Prospects platform.</div>
-            </td>
-        </tr>
-    </table>
+    <p style=\"font-size: 13px; color: #333; margin-bottom: 24px;\">${analysis.summary}</p>
+
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Prospect Score</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px;\">${analysis.prospect_score} / 100 (Grade: <strong>${analysis.prospect_grade}</strong>)</p>
+    </div>
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Recommendation</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px;\">${analysis.recommendation}</p>
+    </div>
+
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Role Inference</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px;\">${analysis.role_inference}</p>
+    </div>
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Seniority Level</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px; text-transform: capitalize;\">${analysis.seniority_level}</p>
+    </div>
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Decision Power</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px; text-transform: capitalize;\">${analysis.decision_power}</p>
+    </div>
+
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Key Priorities</h4>
+        <ul style=\"margin: 8px 0 0 18px; color: #444; font-size: 13px;\">
+            ${(analysis.key_priorities || []).map((item: string) => `<li>${item}</li>`).join('')}
+        </ul>
+    </div>
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Likely Pain Points</h4>
+        <ul style=\"margin: 8px 0 0 18px; color: #444; font-size: 13px;\">
+            ${(analysis.likely_pain_points || []).map((item: string) => `<li>${item}</li>`).join('')}
+        </ul>
+    </div>
+    <div style=\"margin-bottom: 18px;\">
+        <h4 style=\"margin: 0 0 4px 0; font-size: 15px; color: #222;\">Intent Alignment</h4>
+        <p style=\"margin: 0 0 8px 0; color: #444; font-size: 13px;\">${analysis.intent_alignment}</p>
+    </div>
+
+    <hr style=\"border: none; border-top: 1px solid #eee; margin: 24px 0 16px 0;\" />
+    <div style=\"color: #aaa; font-size: 13px;\">Sent with Prospects° by <a href=\"https://goldlabel.pro\" style=\"color: #364450; text-decoration: none; font-weight: bold;\">NX°</a></div>
 </div>
 `;
         const payload = { to, subject, html };


### PR DESCRIPTION
Update the analysis email HTML and subject line for improved styling and clarity. Changed subject from "Analysis for ..." to "Analysis of ..." and replaced the old table-based layout with a single responsive div, refreshed colors/typography, added Prospect branding (Prospects°) and NX° footer, and reorganized sections to emphasize summary, score, recommendation, and detailed attributes. Preserves key lists (priorities, pain points) and data fields while producing a cleaner, Gmail-friendly email payload.