### PR TITLE
Revise pricing page: SaaS, OSS, setup fees

### DIFF
--- a/public/free/markdown/pricing.md
+++ b/public/free/markdown/pricing.md
@@ -1,18 +1,28 @@
 ---
 order: 2000
 title: Pricing
-description: Understanding costs
+description: Start free and scale up as needed
 slug: /pricing
 tags: javascript, nextjs, frontend, backend, resend
 icon: cash
+image: https://live.staticflickr.com/65535/55196635250_f69fd14b3f_c.jpg
 ---
-Flexible plans start free and scale up as needed
+> [CleverText text="SaaS ensures a hassle free experience with access to the latest improvements"]
 
-[CleverText text="Only pay for what you use"]
+#### NX as a Service (SaaS)
 
-- **Free**: 100 emails/day limit, 1 domain, 30-day data retention, ticket support
-- **Pro**: No daily limit, 10 domains, 30-day data retention, ticket support
-- **Scale**: No daily limit, 1,000 domains, 30-day data retention, Slack & ticket support, dedicated IP add-on
-- **Enterprise**: Flexible limits, flexible domains, flexible data retention, priority support, dedicated IPs
+For clients who prefer a fully managed experience, we offer NX as a Service. We handle setup, hosting, updates, and ongoing management. Clients receive their own dedicated tenant on a custom domain, with essential apps like Orders° and the EchoPay OpenBank plugin included. 
 
-All plans include: RESTful API, SMTP relay, official SDKs, inbound emails, batch sending, open & link tracking, React Email, multi-region, DKIM/SPF/DMARC, webhooks, SOC 2 Type II, GDPR compliance, MFA, and API key permissions.
+Pricing starts at **£500/month**, with the final cost depending on selected features. 
+
+#### Free & Open Source
+
+The core NX platform is free and open source on [GitHub](https://github.com/goldlabelapps/nx). Anyone can deploy their own independent tenant, similar to how WordPress operates. This option is ideal for those who want full control and are comfortable with self-hosting.
+
+- Open source code, updated regularly  
+- Community support via GitHub  
+- Guaranteed to remain free and open source
+
+#### Setup & Configured
+
+For a one-time flat fee of **£1000**, we set up and configure NX for you, resolve any initial issues, and hand over the instance after two weeks. Ongoing management is not included, but you retain full control


### PR DESCRIPTION
Update pricing.md frontmatter and content to introduce NX as a Service and self-hosted options. Changed description and added an image; inserted a CleverText callout and a new “NX as a Service (SaaS)” section describing managed hosting and a starting price of £500/month. Added a “Free & Open Source” section with a GitHub link and community details, plus a “Setup & Configured” one-time fee (£1000). Removed the previous detailed plan bullets and the generic “All plans include” line to streamline the page.